### PR TITLE
Fixed to check only merge request with state "closed" or "open". 

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -104,11 +104,9 @@ public class GitlabAPI {
         List<GitlabMergeRequest> openMergeRequests = new ArrayList<GitlabMergeRequest>();
 
         for (GitlabMergeRequest mergeRequest : allMergeRequests) {
-            boolean closedState = (mergeRequest.getState() != null && mergeRequest.getState().equals("closed"));
-            if (closedState || mergeRequest.isClosed()) {
+            if (mergeRequest.isMerged() || mergeRequest.isClosed()) {
                 continue;
             }
-
             openMergeRequests.add(mergeRequest);
         }
 

--- a/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
@@ -100,5 +100,9 @@ public class GitlabMergeRequest {
 
     public void setState(String state) {
         _state = state;
+        if(state != null) {
+            _closed = state.equals("closed");
+            _merged = state.equals("merged");
+        }
     }
 }


### PR DESCRIPTION
Current API uses a string to indicate "closed" and "merged" state. In future we have two boolean variables [1]. For backward reasons we parse the state in the model.

[1] https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/merge_requests.md
