### PR TITLE
fix maven compiler plugin bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,4 +76,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
On my laptop, compiling this project will get the following errors:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project java-gitlab-api: Compilation failure: Compilation failure:

This fix is for the error.
