### PR TITLE
Resolves timols/java-gitlab-api/issues/33

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -582,9 +582,8 @@ public class GitlabAPI {
 
     // gets all commits for a project
     public List<GitlabCommit> getAllCommits(String projectId) throws IOException {
-       String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/repository/commits";
-       GitlabCommit[] commits = retrieve().to(tailUrl, GitlabCommit[].class);
-       return Arrays.asList(commits);
+       String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) +  "/repository" + GitlabCommit.URL;
+       return retrieve().getAll(tailUrl, GitlabCommit[].class);
     }
 
     // List commit diffs for a project ID and commit hash

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -28,6 +28,7 @@ import javax.net.ssl.X509TrustManager;
 
 import org.apache.commons.io.IOUtils;
 import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.models.GitlabCommit;
 
 /**
  * Gitlab HTTP Requestor
@@ -235,9 +236,16 @@ public class GitlabHTTPRequestor {
                     Integer page = Integer.parseInt(matcher.group(2)) + 1;
                     _url = new URL(matcher.replaceAll(matcher.group(1) + "page=" + page));
                 } else {
-                    // Since the page query was not present, its safe to assume that we just
-                    // currently used the first page, so we can default to page 2
-                    _url = new URL(url + "&page=2");
+                    if (GitlabCommit[].class == type) {
+                        // there is a bug in the Gitlab CE API
+                        // (https://gitlab.com/gitlab-org/gitlab-ce/issues/759)
+                        // that starts pagination with page=0 for commits 
+                        _url = new URL(url + "&page=1");
+                    } else {
+                        // Since the page query was not present, its safe to assume that we just
+                        // currently used the first page, so we can default to page 2
+                        _url = new URL(url + "&page=2");
+                    }
                 }
             }
         };

--- a/src/main/java/org/gitlab/api/models/GitlabCommit.java
+++ b/src/main/java/org/gitlab/api/models/GitlabCommit.java
@@ -96,4 +96,17 @@ public class GitlabCommit {
     public void setParentIds(List<String> parentIds) {
         _parentIds = parentIds;
     }
+
+	@Override
+	public boolean equals(Object obj) {
+		// we say that two commit objects are equal iff they have the same ID
+		// this prevents us from having to do clever workarounds for
+		// https://gitlab.com/gitlab-org/gitlab-ce/issues/759
+		try {
+			GitlabCommit commitObj = (GitlabCommit) obj;
+			return (this.getId().compareTo(commitObj.getId()) == 0);
+		} catch (ClassCastException e) {
+			return false;
+		}
+	}
 }


### PR DESCRIPTION
There is a bug in the REST API for Gitlab when retrieving commits with
pagination (https://gitlab.com/gitlab-org/gitlab-ce/issues/759). This
commit is a workaround for that - when we are retrieving commits, we
assume that the second page is numbered 1 instead of 2.

To make this not cause problems if/when the Gitlab CE project fixes the
REST API, equals() is overridden in GitlabCommit to prevent duplicate
entries.
