### PR TITLE
Updated GitlabMergeRequest to match the response

### DIFF
--- a/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
@@ -2,18 +2,26 @@ package org.gitlab.api.models;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import java.util.Date;
+
 public class GitlabMergeRequest {
     public static final String URL = "/merge_requests";
 
     private Integer _id;
     private Integer _iid;
+
+    @JsonProperty("project_id")
+    private Integer _projectId;
+
     private String _title;
-    private String _state;
     private String _description;
-    private boolean _closed;
-    private boolean _merged;
-    private GitlabUser _author;
-    private GitlabUser _assignee;
+    private String _state;
+
+    @JsonProperty("created_at")
+    private Date _createdAt;
+
+    @JsonProperty("updated_at")
+    private Date _updatedAt;
 
     @JsonProperty("target_branch")
     private String _targetBranch;
@@ -21,15 +29,20 @@ public class GitlabMergeRequest {
     @JsonProperty("source_branch")
     private String _sourceBranch;
 
-    @JsonProperty("project_id")
-    private Integer _projectId;
+    private int _upvotes;
+    private int _downvotes;
+    private GitlabUser _author;
+    private GitlabUser _assignee;
 
     @JsonProperty("source_project_id")
     private Integer _sourceProjectId;
 
-    @JsonProperty("milestone_id")
-    private Integer _milestone_id;
+    @JsonProperty("target_project_id")
+    private Integer _targetProjectId;
 
+    private String[] _labels;
+
+    private GitlabMilestone _milestone;
 
     public Integer getId() {
         return _id;
@@ -39,15 +52,60 @@ public class GitlabMergeRequest {
         _id = id;
     }
 
-    public Integer getMilestoneId(){ return _milestone_id; }
-    public void setMilestoneId(Integer id) { _milestone_id = id; }
-
     public Integer getIid() {
         return _iid;
     }
 
     public void setIid(Integer iid) {
         _iid = iid;
+    }
+
+    public Integer getProjectId() {
+        return _projectId;
+    }
+
+    public void setProjectId(Integer projectId) {
+        _projectId = projectId;
+    }
+
+    public String getTitle() {
+        return _title;
+    }
+
+    public void setTitle(String title) {
+        _title = title;
+    }
+
+    public String getDescription() {
+        return _description;
+    }
+
+    public void setDescription(String d) {
+        _description = d;
+    }
+
+    public String getState() {
+        return _state;
+    }
+
+    public void setState(String state) {
+        _state = state;
+    }
+
+    public Date getCreatedAt() {
+        return _createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        _createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return _updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        _updatedAt = updatedAt;
     }
 
     public String getTargetBranch() {
@@ -66,48 +124,20 @@ public class GitlabMergeRequest {
         _sourceBranch = sourceBranch;
     }
 
-    public Integer getProjectId() {
-        return _projectId;
+    public int getUpvotes() {
+        return _upvotes;
     }
 
-    public void setProjectId(Integer projectId) {
-        _projectId = projectId;
+    public void setUpvotes(int upvotes) {
+        _upvotes = upvotes;
     }
 
-    public Integer getSourceProjectId() {
-        return _sourceProjectId;
+    public int getDownvotes() {
+        return _downvotes;
     }
 
-    public void setSourceProjectId(Integer sourceProjectId) {
-        _sourceProjectId = sourceProjectId;
-    }
-
-    public String getTitle() {
-        return _title;
-    }
-
-    public void setTitle(String title) {
-        _title = title;
-    }
-
-    public String getDescription() { return _description; }
-
-    public void setDescription(String d) { _description = d; }
-
-    public boolean isClosed() {
-        return _closed;
-    }
-
-    public void setClosed(boolean closed) {
-        _closed = closed;
-    }
-
-    public boolean isMerged() {
-        return _merged;
-    }
-
-    public void setMerged(boolean merged) {
-        _merged = merged;
+    public void setDownvotes(int downvotes) {
+        _downvotes = downvotes;
     }
 
     public GitlabUser getAuthor() {
@@ -126,15 +156,35 @@ public class GitlabMergeRequest {
         _assignee = assignee;
     }
 
-    public String getState() {
-        return _state;
+    public Integer getSourceProjectId() {
+        return _sourceProjectId;
     }
 
-    public void setState(String state) {
-        _state = state;
-        if(state != null) {
-            _closed = state.equals("closed");
-            _merged = state.equals("merged");
-        }
+    public void setSourceProjectId(Integer sourceProjectId) {
+        _sourceProjectId = sourceProjectId;
+    }
+
+    public Integer getTargetProjectId() {
+        return _targetProjectId;
+    }
+
+    public void setTargetProjectId(int targetProjectId) {
+        _targetProjectId = targetProjectId;
+    }
+
+    public String[] getLabels() {
+        return _labels;
+    }
+
+    public void setLabels(String[] labels) {
+        _labels = labels;
+    }
+
+    public GitlabMilestone getMilestone() {
+        return _milestone;
+    }
+
+    public void setMilestone(GitlabMilestone milestone) {
+        _milestone = milestone;
     }
 }


### PR DESCRIPTION
Updated the GitlabMergeRequest model to reflect the right json delivered by the server.

I don't know if you want to support older versions of gitlab, and thus want to keep the _closed, _merged, and _milestoneId variables, but in this commit I removed those.
Tell me if I should move them back in.
