### PR TITLE
Fix crash when deleting a project

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -521,7 +521,7 @@ public class GitlabAPI {
      */
     public void deleteProject(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId);
-        retrieve().method("DELETE").to(tailUrl, Void.class);
+        retrieve().method("DELETE").to(tailUrl, null);
     }
 
     public List<GitlabMergeRequest> getOpenMergeRequests(Serializable projectId) throws IOException {


### PR DESCRIPTION
This fixes a crash in the `deleteProject` method. The stack trace I received for the (fixed) crash is below.

```
org.codehaus.jackson.map.JsonMappingException: Can not instantiate value of type [simple type, class java.lang.Void] from JSON boolean value; no single-boolean/Boolean-arg constructor/factory method
	at org.codehaus.jackson.map.deser.std.StdValueInstantiator.createFromBoolean(StdValueInstantiator.java:328)
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserializeFromBoolean(BeanDeserializer.java:855)
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserialize(BeanDeserializer.java:594)
	at org.codehaus.jackson.map.ObjectMapper._readMapAndClose(ObjectMapper.java:2732)
	at org.codehaus.jackson.map.ObjectMapper.readValue(ObjectMapper.java:1863)
	at org.gitlab.api.http.GitlabHTTPRequestor.parse(GitlabHTTPRequestor.java:286)
	at org.gitlab.api.http.GitlabHTTPRequestor.to(GitlabHTTPRequestor.java:124)
	at org.gitlab.api.http.GitlabHTTPRequestor.to(GitlabHTTPRequestor.java:99)
	at org.gitlab.api.GitlabAPI.deleteProject(GitlabAPI.java:524)
```