### PR TITLE
Dependency Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,148 +1,149 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.gitlab</groupId>
-    <artifactId>java-gitlab-api</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+	<groupId>org.gitlab</groupId>
+	<artifactId>java-gitlab-api</artifactId>
+	<version>1.1.8-SNAPSHOT</version>
 
-    <name>Gitlab Java API Wrapper</name>
-    <description>A Java wrapper for the Gitlab Git Hosting Server API</description>
+	<name>Gitlab Java API Wrapper</name>
+	<description>A Java wrapper for the Gitlab Git Hosting Server API</description>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>9</version>
+	</parent>
 
-    <developers>
-        <developer>
-            <id>timols</id>
-            <name>Tim Olshansky</name>
-            <email>tim.olshansky@gmail.com</email>
-        </developer>
-    </developers>
-    <contributors>
-        <contributor>
-            <name>Adam Retter</name>
-            <email>adam.retter@googlemail.com</email>
-            <organization>Evolved Binary Ltd</organization>
-        </contributor>
-	<contributor>
-            <name>Cesar Aguilar</name>
-            <email>cesar@fuzzproductions.com</email>
-            <organization>Fuzz Productions</organization>
-        </contributor>
-	<contributor>
-            <name>Chris Luu</name>
-            <email>luu@fuzzproductions.com</email>
-            <organization>Fuzz Productions</organization>
-        </contributor>
-    </contributors>
+	<developers>
+		<developer>
+			<id>timols</id>
+			<name>Tim Olshansky</name>
+			<email>tim.olshansky@gmail.com</email>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Adam Retter</name>
+			<email>adam.retter@googlemail.com</email>
+			<organization>Evolved Binary Ltd</organization>
+		</contributor>
+		<contributor>
+			<name>Cesar Aguilar</name>
+			<email>cesar@fuzzproductions.com</email>
+			<organization>Fuzz Productions</organization>
+		</contributor>
+		<contributor>
+			<name>Chris Luu</name>
+			<email>luu@fuzzproductions.com</email>
+			<organization>Fuzz Productions</organization>
+		</contributor>
+	</contributors>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
-    <scm>
-        <connection>scm:git:ssh://github.com/timols/java-gitlab-api.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/timols/java-gitlab-api.git</developerConnection>
-        <url>https://github.com/timols/java-gitlab-api</url>
-    </scm>
+	<scm>
+		<connection>scm:git:ssh://github.com/timols/java-gitlab-api.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/timols/java-gitlab-api.git</developerConnection>
+		<url>https://github.com/timols/java-gitlab-api</url>
+	</scm>
 
-    <issueManagement>
-        <system>Github</system>
-        <url>https://github.com/timols/java-gitlab-api/issues</url>
-    </issueManagement>
+	<issueManagement>
+		<system>Github</system>
+		<url>https://github.com/timols/java-gitlab-api/issues</url>
+	</issueManagement>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    </properties>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.13</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.5.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.5.3</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.17</version>
-                <executions>
-                    <execution>
-                        <id>default-integration-test</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-verify</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                  <execution>
-                    <id>attach-sources</id>
-                    <phase>verify</phase>
-                    <goals>
-                      <goal>jar-no-fork</goal>
-                  </goals>
-                </execution>
-              </executions>
-          </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5.1</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.17</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.17</version>
+				<executions>
+					<execution>
+						<id>default-integration-test</id>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>default-verify</id>
+						<goals>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1,19 +1,35 @@
 package org.gitlab.api;
 
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.gitlab.api.http.GitlabHTTPRequestor;
-import org.gitlab.api.http.Query;
-import org.gitlab.api.models.*;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.gitlab.api.http.GitlabHTTPRequestor;
+import org.gitlab.api.http.Query;
+import org.gitlab.api.models.GitlabAccessLevel;
+import org.gitlab.api.models.GitlabBranch;
+import org.gitlab.api.models.GitlabCommit;
+import org.gitlab.api.models.GitlabCommitDiff;
+import org.gitlab.api.models.GitlabGroup;
+import org.gitlab.api.models.GitlabGroupMember;
+import org.gitlab.api.models.GitlabIssue;
+import org.gitlab.api.models.GitlabMergeRequest;
+import org.gitlab.api.models.GitlabMilestone;
+import org.gitlab.api.models.GitlabNamespace;
+import org.gitlab.api.models.GitlabNote;
+import org.gitlab.api.models.GitlabProject;
+import org.gitlab.api.models.GitlabProjectHook;
+import org.gitlab.api.models.GitlabProjectMember;
+import org.gitlab.api.models.GitlabSSHKey;
+import org.gitlab.api.models.GitlabSession;
+import org.gitlab.api.models.GitlabUser;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 /**
@@ -23,7 +39,7 @@ import java.util.List;
  */
 public class GitlabAPI {
 
-    public static final ObjectMapper MAPPER = new ObjectMapper().configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    public static final ObjectMapper MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private static final String API_NAMESPACE = "/api/v3";
     private static final String PARAM_SUDO = "sudo";

--- a/src/main/java/org/gitlab/api/models/GitlabAbstractMember.java
+++ b/src/main/java/org/gitlab/api/models/GitlabAbstractMember.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public abstract class GitlabAbstractMember extends GitlabUser {
 

--- a/src/main/java/org/gitlab/api/models/GitlabAccessLevel.java
+++ b/src/main/java/org/gitlab/api/models/GitlabAccessLevel.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum GitlabAccessLevel {
     Guest(10),

--- a/src/main/java/org/gitlab/api/models/GitlabBranch.java
+++ b/src/main/java/org/gitlab/api/models/GitlabBranch.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabBranch {
     public final static String URL = "/repository/branches/";

--- a/src/main/java/org/gitlab/api/models/GitlabBranchCommit.java
+++ b/src/main/java/org/gitlab/api/models/GitlabBranchCommit.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabBranchCommit {
     public static String URL = "/users";

--- a/src/main/java/org/gitlab/api/models/GitlabCommit.java
+++ b/src/main/java/org/gitlab/api/models/GitlabCommit.java
@@ -1,9 +1,9 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabCommit {
 

--- a/src/main/java/org/gitlab/api/models/GitlabCommitDiff.java
+++ b/src/main/java/org/gitlab/api/models/GitlabCommitDiff.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabCommitDiff {
 

--- a/src/main/java/org/gitlab/api/models/GitlabGroup.java
+++ b/src/main/java/org/gitlab/api/models/GitlabGroup.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabGroup {
 

--- a/src/main/java/org/gitlab/api/models/GitlabIssue.java
+++ b/src/main/java/org/gitlab/api/models/GitlabIssue.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabIssue {
 

--- a/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabMergeRequest {
     public static final String URL = "/merge_requests";

--- a/src/main/java/org/gitlab/api/models/GitlabMilestone.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMilestone.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabMilestone {
 

--- a/src/main/java/org/gitlab/api/models/GitlabNamespace.java
+++ b/src/main/java/org/gitlab/api/models/GitlabNamespace.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabNamespace {
     public static final String URL = "/groups";

--- a/src/main/java/org/gitlab/api/models/GitlabNote.java
+++ b/src/main/java/org/gitlab/api/models/GitlabNote.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabNote {
 

--- a/src/main/java/org/gitlab/api/models/GitlabPermission.java
+++ b/src/main/java/org/gitlab/api/models/GitlabPermission.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabPermission {
 

--- a/src/main/java/org/gitlab/api/models/GitlabProject.java
+++ b/src/main/java/org/gitlab/api/models/GitlabProject.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabProject {
 

--- a/src/main/java/org/gitlab/api/models/GitlabProjectAccessLevel.java
+++ b/src/main/java/org/gitlab/api/models/GitlabProjectAccessLevel.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabProjectAccessLevel {
 

--- a/src/main/java/org/gitlab/api/models/GitlabProjectHook.java
+++ b/src/main/java/org/gitlab/api/models/GitlabProjectHook.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabProjectHook {
 

--- a/src/main/java/org/gitlab/api/models/GitlabSSHKey.java
+++ b/src/main/java/org/gitlab/api/models/GitlabSSHKey.java
@@ -1,8 +1,5 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
-import java.util.Date;
 
 public class GitlabSSHKey {
     public static String KEYS_URL = "/keys";

--- a/src/main/java/org/gitlab/api/models/GitlabSession.java
+++ b/src/main/java/org/gitlab/api/models/GitlabSession.java
@@ -1,6 +1,6 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabSession extends GitlabUser {
 

--- a/src/main/java/org/gitlab/api/models/GitlabUser.java
+++ b/src/main/java/org/gitlab/api/models/GitlabUser.java
@@ -1,8 +1,8 @@
 package org.gitlab.api.models;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabUser {
     public static String URL = "/users";


### PR DESCRIPTION
Upgraded the Jackson dependencies from Codehouse libs to Fasterxml as when using the API with some projects which already have fasterxml.jackson on the classpath, the jackson dependencies are duplicated. Still this is no problem as the packages are not the same, but it is always nice to have a clean classpath. So may be you can have 2 versions of API one with Codehouse Jackson (1.1.x) and one with the Fasterxml Jackson (1.2.x).