### PR TITLE
Support OAuth access_token

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -30,22 +30,28 @@ public class GitlabAPI {
     private final String hostUrl;
 
     private final String apiToken;
+    private final TokenType tokenType;
     private boolean ignoreCertificateErrors = false;
 
-    private GitlabAPI(String hostUrl, String apiToken) {
+    private GitlabAPI(String hostUrl, String apiToken, TokenType tokenType) {
         this.hostUrl = hostUrl.endsWith("/") ? hostUrl.replaceAll("/$", "") : hostUrl;
         this.apiToken = apiToken;
+        this.tokenType = tokenType;
     }
 
     public static GitlabSession connect(String hostUrl, String username, String password) throws IOException {
         String tailUrl = GitlabSession.URL;
-        GitlabAPI api = connect(hostUrl, null);
+        GitlabAPI api = connect(hostUrl, null, (TokenType) null);
         return api.dispatch().with("login", username).with("password", password)
                 .to(tailUrl, GitlabSession.class);
     }
 
     public static GitlabAPI connect(String hostUrl, String apiToken) {
-        return new GitlabAPI(hostUrl, apiToken);
+        return new GitlabAPI(hostUrl, apiToken, TokenType.PRIVATE_TOKEN);
+    }
+
+    public static GitlabAPI connect(String hostUrl, String apiToken, TokenType tokenType) {
+        return new GitlabAPI(hostUrl, apiToken, tokenType);
     }
 
     public GitlabAPI ignoreCertificateErrors(boolean ignoreCertificateErrors) {
@@ -67,7 +73,7 @@ public class GitlabAPI {
 
     public URL getAPIUrl(String tailAPIUrl) throws IOException {
         if (apiToken != null) {
-            tailAPIUrl = tailAPIUrl + (tailAPIUrl.indexOf('?') > 0 ? '&' : '?') + "private_token=" + apiToken;
+            tailAPIUrl = tailAPIUrl + (tailAPIUrl.indexOf('?') > 0 ? '&' : '?') + tokenType.getTokenParamName() + "=" + apiToken;
         }
 
         if (!tailAPIUrl.startsWith("/")) {

--- a/src/main/java/org/gitlab/api/TokenType.java
+++ b/src/main/java/org/gitlab/api/TokenType.java
@@ -1,0 +1,17 @@
+package org.gitlab.api;
+
+public enum TokenType {
+	  PRIVATE_TOKEN("private_token")
+	, ACCESS_TOKEN("access_token"),
+	;
+
+	private final String tokenParamName;
+
+	TokenType(String tokenParamName) {
+		this.tokenParamName = tokenParamName;
+	}
+
+	public String getTokenParamName() {
+		return tokenParamName;
+	}
+}

--- a/src/test/java/org/gitlab/api/http/GitlabHTTPRequestorTest.java
+++ b/src/test/java/org/gitlab/api/http/GitlabHTTPRequestorTest.java
@@ -1,6 +1,7 @@
 package org.gitlab.api.http;
 
 import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.TokenType;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
For OAuth the uri query parameter should be named access_token instead of
private_token. To support both a enum TokenType is introduced and should
be used to select which token type to be used for the API access.

For backwards compatibility TokenType#PRIVATE_TOKEN will be used by
default.

Signed-off-by: Andreas Häber <andreas.haber@intele.com>