### PR TITLE
Add API method for get SSH key with user information by ID of an SSH key: getSSHKey

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -280,6 +280,18 @@ public class GitlabAPI {
     }
 
     /**
+     * Get key with user information by ID of an SSH key.
+     *
+     * @param keyId The ID of an SSH key
+     * @return The SSH key with user information
+     * @throws IOException on gitlab api call error
+     */
+    public GitlabSSHKey getSSHKey(Integer keyId) throws IOException {
+        String tailUrl = GitlabSSHKey.KEYS_URL + "/" + keyId;
+        return retrieve().to(tailUrl, GitlabSSHKey.class);
+    }
+
+    /**
      * Delete a user
      *
      * @param targetUserId  The target User ID

--- a/src/main/java/org/gitlab/api/models/GitlabSSHKey.java
+++ b/src/main/java/org/gitlab/api/models/GitlabSSHKey.java
@@ -7,6 +7,7 @@ public class GitlabSSHKey {
     private Integer _id;
     private String _title;
     private String _key;
+    private GitlabUser _user;
 
     public Integer getId() {
         return _id;
@@ -30,5 +31,13 @@ public class GitlabSSHKey {
 
     public void setKey(String key) {
         _key = key;
+    }
+
+    public GitlabUser getUser() {
+        return _user;
+    }
+
+    public void setUser(GitlabUser user) {
+        _user = user;
     }
 }


### PR DESCRIPTION
API function was introduced by PR: https://github.com/gitlabhq/gitlabhq/pull/9591

## Get SSH key with user by ID of an SSH key

Get SSH key with user by ID of an SSH key. Note only administrators can lookup SSH key with user by ID of an SSH key.

```
GET /keys/:id
```

Parameters:

- `id` (required) - The ID of an SSH key

```json
{
  "id": 1,
  "title": "Sample key 25",
  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt1256k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=",
  "created_at": "2015-09-03T07:24:44.627Z",
  "user": {
    "name": "John Smith",
    "username": "john_smith",
    "id": 25,
    "state": "active",
    "avatar_url": "http://www.gravatar.com/avatar/cfa35b8cd2ec278026357769582fa563?s=40\u0026d=identicon",
    "web_url": "http://localhost:3000/u/john_smith",
    "created_at": "2015-09-03T07:24:01.670Z",
    "is_admin": false,
    "bio": null,
    "skype": "",
    "linkedin": "",
    "twitter": "",
    "website_url": "",
    "email": "john@example.com",
    "theme_id": 2,
    "color_scheme_id": 1,
    "projects_limit": 10,
    "current_sign_in_at": null,
    "identities": [],
    "can_create_group": true,
    "can_create_project": true,
    "two_factor_enabled": false
  }
}
```
