### PR TITLE
Correct name of GitlabAPI Test

### DIFF
--- a/src/test/java/org/gitlab/api/GitlabAPITest.java
+++ b/src/test/java/org/gitlab/api/GitlabAPITest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeNoException;
 
 @Ignore
-public class GitlabAPIT {
+public class GitlabAPITest {
 
     GitlabAPI api;
 


### PR DESCRIPTION
JUnit ignores GitlabAPIT because of wrong naming. Fixes naming issue.