### PR TITLE
Add Method to get a single Merge Request Note

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -662,6 +662,22 @@ public class GitlabAPI {
         return requestor.to(tailUrl, GitlabMergeRequest.class);
     }
 
+    /**
+     * Get a Note from a Merge Request.
+     *
+     * @param mergeRequest         The merge request
+     * @param noteId               The id of the note
+     * @return the Gitlab Note
+     * @throws IOException on gitlab api call error
+     */
+    public GitlabNote getNote(GitlabMergeRequest mergeRequest, Integer noteId) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + mergeRequest.getProjectId() +
+                GitlabMergeRequest.URL + "/" + mergeRequest.getId() +
+                GitlabNote.URL + "/" + noteId;
+
+        return retrieve().to(tailUrl, GitlabNote.class);
+    }
+
     public List<GitlabNote> getNotes(GitlabMergeRequest mergeRequest) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + mergeRequest.getProjectId() +
                 GitlabMergeRequest.URL + "/" + mergeRequest.getId() +


### PR DESCRIPTION
Implements the following Gitlab API Call: http://doc.gitlab.com/ce/api/notes.html#get-single-merge-request-note