### PR TITLE
Implement Authentication via an HTTP Header 

### DIFF
--- a/src/main/java/org/gitlab/api/AuthMethod.java
+++ b/src/main/java/org/gitlab/api/AuthMethod.java
@@ -1,0 +1,5 @@
+package org.gitlab.api;
+
+public enum AuthMethod {
+    HEADER, URL_PARAMETER
+}

--- a/src/main/java/org/gitlab/api/TokenType.java
+++ b/src/main/java/org/gitlab/api/TokenType.java
@@ -1,17 +1,35 @@
 package org.gitlab.api;
 
 public enum TokenType {
-	  PRIVATE_TOKEN("private_token")
-	, ACCESS_TOKEN("access_token"),
-	;
+	PRIVATE_TOKEN("private_token", "PRIVATE-TOKEN", "%s"),
+	ACCESS_TOKEN("access_token", "Authorization", "Bearer %s");
 
 	private final String tokenParamName;
+	private final String tokenHeaderName;
+	private final String tokenHeaderFormat;
 
-	TokenType(String tokenParamName) {
+    /**
+     * Constructor
+     *
+     * @param tokenParamName    The url parameter name when using AuthMethod.URL_PARAMETER
+	 * @param tokenHeaderName   The header name when using AuthMethod.HEADER
+	 * @param tokenHeaderFormat The header format for String.format when using AuthMethod.HEADER
+     */
+	TokenType(String tokenParamName, String tokenHeaderName, String tokenHeaderFormat) {
 		this.tokenParamName = tokenParamName;
+		this.tokenHeaderName = tokenHeaderName;
+		this.tokenHeaderFormat = tokenHeaderFormat;
 	}
 
 	public String getTokenParamName() {
 		return tokenParamName;
+	}
+
+	public String getTokenHeaderName() {
+		return tokenHeaderName;
+	}
+
+	public String getTokenHeaderFormat() {
+		return tokenHeaderFormat;
 	}
 }

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -1,7 +1,9 @@
 package org.gitlab.api.http;
 
 import org.apache.commons.io.IOUtils;
+import org.gitlab.api.AuthMethod;
 import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.TokenType;
 import org.gitlab.api.models.GitlabCommit;
 
 import javax.net.ssl.*;
@@ -34,6 +36,10 @@ public class GitlabHTTPRequestor {
     private String method = "GET"; // Default to GET requests
     private Map<String, Object> data = new HashMap<String, Object>();
 
+    private String apiToken;
+    private TokenType tokenType;
+    private AuthMethod authMethod;
+
     private enum METHOD {
         GET, PUT, POST, PATCH, DELETE, HEAD, OPTIONS, TRACE;
 
@@ -54,6 +60,22 @@ public class GitlabHTTPRequestor {
 
     public GitlabHTTPRequestor(GitlabAPI root) {
         this.root = root;
+    }
+
+    /**
+     * Sets authentication data for the request.
+     * Has a fluent api for method chaining.
+     *
+     * @param token  The token value
+     * @param type   The type of the token
+     * @param method The authentication method
+     * @return this
+     */
+    public GitlabHTTPRequestor authenticate(String token, TokenType type, AuthMethod method) {
+        this.apiToken = token;
+        this.tokenType = type;
+        this.authMethod = method;
+        return this;
     }
 
     /**
@@ -236,11 +258,11 @@ public class GitlabHTTPRequestor {
                         // there is a bug in the Gitlab CE API
                         // (https://gitlab.com/gitlab-org/gitlab-ce/issues/759)
                         // that starts pagination with page=0 for commits
-                        this.url = new URL(url + "&page=1");
+                        this.url = new URL(url + (url.indexOf('?') > 0 ? '&' : '?') + "page=1");
                     } else {
                         // Since the page query was not present, its safe to assume that we just
                         // currently used the first page, so we can default to page 2
-                        this.url = new URL(url + "&page=2");
+                        this.url = new URL(url + (url.indexOf('?') > 0 ? '&' : '?') + "&page=2");
                     }
                 }
             }
@@ -262,7 +284,16 @@ public class GitlabHTTPRequestor {
             ignoreCertificateErrors();
         }
 
+        if (apiToken != null && authMethod == AuthMethod.URL_PARAMETER) {
+            String urlWithAuth = url.toString();
+            urlWithAuth = urlWithAuth + (urlWithAuth.indexOf('?') > 0 ? '&' : '?') + tokenType.getTokenParamName() + "=" + apiToken;
+            url = new URL(urlWithAuth);
+        }
+
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        if (apiToken != null && authMethod == AuthMethod.HEADER) {
+            connection.setRequestProperty(tokenType.getTokenHeaderName(), String.format(tokenType.getTokenHeaderFormat(), apiToken));
+        }
 
         try {
             connection.setRequestMethod(method);

--- a/src/test/java/org/gitlab/api/GitlabAPITest.java
+++ b/src/test/java/org/gitlab/api/GitlabAPITest.java
@@ -41,13 +41,18 @@ public class GitlabAPITest {
     }
 
     @Test
+    public void testAllProjects() throws IOException {
+        api.getAllProjects();
+    }
+
+    @Test
     public void testConnect() throws IOException {
         assertEquals(GitlabAPI.class, api.getClass());
     }
 
     @Test
     public void testGetAPIUrl() throws IOException {
-        URL expected = new URL(TEST_URL + "/api/v3/?private_token=" + TEST_TOKEN);
+        URL expected = new URL(TEST_URL + "/api/v3/");
         assertEquals(expected, api.getAPIUrl(""));
     }
 


### PR DESCRIPTION
Fixes #79.

This PR introduced a new authentication method using HTTP Headers.
As we now have 2 different method to authenticate, the constructer of GitlabAPI includes another parameter AuthMethod which is a simple enum.

TokenType was extended with information needed for authentication like Header name and Header format.

The authentication was moved from GitlabAPI to GitlabHTTPRequestor.
Authentication information is passed using a fluent interface:
`return new GitlabHTTPRequestor(this).authenticate(apiToken, tokenType, authMethod).method("POST");`

Tested both using private tokens and access token.

The PR includes only minor compatibility changes:
- getAPIUrl doesn't return the private token anymore.
- Exceptions thrown doesn't include the private token anymore.

This PR sets the HEADER Authentication method as the default.
I think it is beneficial for everyone to hide the token from the request url, which is easily exposed.
