### PR TITLE
Add method to retrieve merge request changes

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -660,6 +660,19 @@ public class GitlabAPI {
         return ls.get(0);
     }
 
+    /**
+     * Return a Merge Request including its changes.
+     *
+     * @param projectId       The id of the project
+     * @param mergeRequestId  The id of the merge request
+     * @return the Gitlab Merge Request
+     * @throws IOException on gitlab api call error
+     */
+    public GitlabMergeRequest getMergeRequestChanges(Serializable projectId, Integer mergeRequestId) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/merge_request/" + mergeRequestId + "/changes";
+        return retrieve().to(tailUrl, GitlabMergeRequest.class);
+    }
+
     public GitlabMergeRequest getMergeRequest(GitlabProject project, Integer mergeRequestId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + project.getId() + "/merge_request/" + mergeRequestId;
         return retrieve().to(tailUrl, GitlabMergeRequest.class);

--- a/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
@@ -1,6 +1,7 @@
 package org.gitlab.api.models;
 
 import java.util.Date;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -19,6 +20,7 @@ public class GitlabMergeRequest {
     private GitlabMilestone milestone;
 
     private String[] labels;
+    private List<GitlabCommitDiff> changes;
 
     private int upvotes;
     private int downvotes;
@@ -223,5 +225,13 @@ public class GitlabMergeRequest {
 
     public void setCreatedAt(Date createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public List<GitlabCommitDiff> getChanges() {
+        return changes;
+    }
+
+    public void setChanges(List<GitlabCommitDiff> changes) {
+        this.changes = changes;
     }
 }


### PR DESCRIPTION
Implements Gitlab API call to get Merge Request Changes: http://doc.gitlab.com/ce/api/merge_requests.html#get-single-mr-changes

Note that in the documentation the JSON Parameter Name is 'files' which is wrong. In fact the Gitlab API uses the JSON Parameter Name 'changes'.