### PR TITLE
Expose HTTP Code through GitlabAPIException

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPIException.java
+++ b/src/main/java/org/gitlab/api/GitlabAPIException.java
@@ -1,0 +1,20 @@
+package org.gitlab.api;
+
+import java.io.IOException;
+
+/**
+ * Gitlab API Exception
+ */
+public class GitlabAPIException extends IOException {
+
+    private int responseCode;
+
+    public GitlabAPIException(String message, Integer responseCode, Throwable cause) {
+        super(message, cause);
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+}

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -3,6 +3,7 @@ package org.gitlab.api.http;
 import org.apache.commons.io.IOUtils;
 import org.gitlab.api.AuthMethod;
 import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.GitlabAPIException;
 import org.gitlab.api.TokenType;
 import org.gitlab.api.models.GitlabCommit;
 
@@ -353,11 +354,11 @@ public class GitlabHTTPRequestor {
 
         InputStream es = wrapStream(connection, connection.getErrorStream());
         try {
+            String error = null;
             if (es != null) {
-                throw (IOException) new IOException(IOUtils.toString(es, "UTF-8")).initCause(e);
-            } else {
-                throw e;
+                error = IOUtils.toString(es, "UTF-8");
             }
+            throw new GitlabAPIException(error, connection.getResponseCode(), e);
         } finally {
             IOUtils.closeQuietly(es);
         }

--- a/src/test/java/org/gitlab/api/GitlabAPITest.java
+++ b/src/test/java/org/gitlab/api/GitlabAPITest.java
@@ -32,10 +32,12 @@ public class GitlabAPITest {
             api.dispatch().with("login", "INVALID").with("password", rand).to("session", GitlabUser.class);
         } catch (ConnectException e) {
             assumeNoException("GITLAB not running on '" + TEST_URL + "', skipping...", e);
-        } catch (IOException e) {
+        } catch (GitlabAPIException e) {
             final String message = e.getMessage();
             if (!message.equals("{\"message\":\"401 Unauthorized\"}")) {
                 throw new AssertionError("Expected an unauthorized message", e);
+            } else if(e.getResponseCode() != 401) {
+                throw new AssertionError("Expected 401 code", e);
             }
         }
     }


### PR DESCRIPTION
Current implementation includes no way of handling the returned http error codes. This PR introduces a GitlabAPIException class which extends from IOException but includes the error code. The changes are 100% backwards compatible.

This is probably the last one of my series of PRs for now :-)