### PR TITLE
Adds create / edit support for milestones

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -12,7 +12,9 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 
@@ -1065,6 +1067,126 @@ public class GitlabAPI {
     public List<GitlabMilestone> getMilestones(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMilestone.URL;
         return Arrays.asList(retrieve().to(tailUrl, GitlabMilestone[].class));
+    }
+
+    /**
+     * Cretaes a new project milestone.
+     * @param projectId The ID of the project.
+     * @param title The title of the milestone.
+     * @param description The description of the milestone. (Optional)
+     * @param dueDate The date the milestone is due. (Optional)
+     * @return The newly created, de-serialized milestone.
+     * @throws IOException
+     */
+    public GitlabMilestone createMilestone(
+            Serializable projectId,
+            String title,
+            String description,
+            Date dueDate) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + projectId + GitlabMilestone.URL;
+        GitlabHTTPRequestor requestor = dispatch().with("title", title);
+        if (description != null) {
+            requestor = requestor.with("description", description);
+        }
+        if (dueDate != null) {
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            String formatted = formatter.format(dueDate);
+            requestor = requestor.with("due_date", formatted);
+        }
+        return requestor.to(tailUrl, GitlabMilestone.class);
+    }
+
+    /**
+     * Creates a new project milestone.
+     * @param projectId The ID of the project.
+     * @param milestone The milestone to create.
+     * @return The newly created, de-serialized milestone.
+     * @throws IOException
+     */
+    public GitlabMilestone createMilestone(
+            Serializable projectId,
+            GitlabMilestone milestone) throws IOException {
+        String title = milestone.getTitle();
+        String description = milestone.getDescription();
+        Date dateDue = milestone.getDueDate();
+        return createMilestone(projectId, title, description, dateDue);
+    }
+
+    /**
+     * Updates an existing project milestone.
+     * @param projectId The ID of the project.
+     * @param milestoneId The ID of the milestone.
+     * @param title The title of the milestone. (Optional)
+     * @param description The description of the milestone. (Optional)
+     * @param dueDate The date the milestone is due. (Optional)
+     * @param stateEvent A value used to update the state of the milestone.
+     *                   (Optional) (activate | close)
+     * @return The updated, de-serialized milestone.
+     * @throws IOException
+     */
+    public GitlabMilestone updateMilestone(
+            Serializable projectId,
+            int milestoneId,
+            String title,
+            String description,
+            Date dueDate,
+            String stateEvent) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" +
+                projectId +
+                GitlabMilestone.URL + "/" +
+                milestoneId;
+        GitlabHTTPRequestor requestor = retrieve().method("PUT");
+        if (title != null) {
+            requestor.with("title", title);
+        }
+        if (description != null) {
+            requestor = requestor.with("description", description);
+        }
+        if (dueDate != null) {
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            String formatted = formatter.format(dueDate);
+            requestor = requestor.with("due_date", formatted);
+        }
+        if (stateEvent != null) {
+            requestor.with("state_event", stateEvent);
+        }
+        return requestor.to(tailUrl, GitlabMilestone.class);
+    }
+
+    /**
+     * Updates an existing project milestone.
+     * @param projectId The ID of the project.
+     * @param edited The already edited milestone.
+     * @param stateEvent A value used to update the state of the milestone.
+     *                   (Optional) (activate | close)
+     * @return The updated, de-serialized milestone.
+     * @throws IOException
+     */
+    public GitlabMilestone updateMilestone(
+            Serializable projectId,
+            GitlabMilestone edited,
+            String stateEvent) throws IOException {
+        return updateMilestone(projectId,
+                edited.getId(),
+                edited.getTitle(),
+                edited.getDescription(),
+                edited.getDueDate(),
+                stateEvent);
+    }
+
+    /**
+     * Updates an existing project milestone.
+     * @param edited The already edited milestone.
+     * @return The updated, de-serialized milestone.
+     * @param stateEvent A value used to update the state of the milestone.
+     *                   (Optional) (activate | close)
+     * @throws IOException
+     */
+    public GitlabMilestone updateMilestone(
+            GitlabMilestone edited,
+            String stateEvent)
+            throws IOException {
+        return updateMilestone(edited.getProjectId(), edited, stateEvent);
     }
 
     /**

--- a/src/main/java/org/gitlab/api/models/GitlabMilestone.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMilestone.java
@@ -9,9 +9,14 @@ public class GitlabMilestone {
     public static final String URL = "/milestones";
 
     private int id;
+
     private int iid;
+
+    @JsonProperty("project_id")
     private int projectId;
+
     private String title;
+
     private String description;
 
     @JsonProperty("due_date")


### PR DESCRIPTION
### Purpose
Wraps "POST" and "PUT" verbs for creating and updating milestones in api version 3.

### Files Updated
* src/main/java/org/gitlab/api/GitlabAPI.java
    * Added overloaded createMilestone methods
    * Added overloaded updateMilestone methods
*  src/main/java/org/gitlab/api/models/GitlabMilestone.java
    * Added JsonProperty for proper deserialization of project ID.  In my testing I was attempting to create a new milestone and update it on the next line of code.  The update was failing because the project ID was zero.  This seemed like the best way to solve the problem, but it can be solved other ways if need be.

### Notes and Thanks
I may have overlooked them, but I didn't see contribution guidelines.  I did test this code, but didn't use the GitlabAPITest :)  I'm also not sure if there are certain kinds of changes you're accepting right now.  My team found this update to be helpful, so I thought I'd pass it on.  If you're interested in this PR and would like any changes, please do let me know and I'll be happy to oblige.  My thanks for this wrapper API.  I'm attempting to transfer a gitlab project from one server to the next and this has come in handy.