### PR TITLE
Adds CRUD support for labels

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1058,6 +1058,114 @@ public class GitlabAPI {
         return createNote(String.valueOf(issue.getProjectId()), issue.getId(), message);
     }
 
+    /**
+     * Gets labels associated with a project.
+     * @param projectId The ID of the project.
+     * @return A non-null list of labels.
+     * @throws IOException
+     */
+    public List<GitlabLabel> getLabels(Serializable projectId)
+            throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + projectId + GitlabLabel.URL;
+        GitlabLabel[] labels = retrieve().to(tailUrl, GitlabLabel[].class);
+        return Arrays.asList(labels);
+    }
+
+    /**
+     * Gets labels associated with a project.
+     * @param project The project associated with labels.
+     * @return A non-null list of labels.
+     * @throws IOException
+     */
+    public List<GitlabLabel> getLabels(GitlabProject project)
+            throws IOException {
+        return getLabels(project.getId());
+    }
+
+    /**
+     * Creates a new label.
+     * @param projectId The ID of the project containing the new label.
+     * @param name The name of the label.
+     * @param color The color of the label (eg #ff0000).
+     * @return The newly created label.
+     * @throws IOException
+     */
+    public GitlabLabel createLabel(
+            Serializable projectId,
+            String name,
+            String color) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + projectId + GitlabLabel.URL;
+        return dispatch().with("name", name)
+                         .with("color", color)
+                         .to(tailUrl, GitlabLabel.class);
+    }
+
+    /**
+     * Creates a new label.
+     * @param projectId The ID of the project containing the label.
+     * @param label The label to create.
+     * @return The newly created label.
+     */
+    public GitlabLabel createLabel(Serializable projectId, GitlabLabel label)
+            throws IOException {
+        String name = label.getName();
+        String color = label.getColor();
+        return createLabel(projectId, name, color);
+    }
+
+    /**
+     * Deletes an existing label.
+     * @param projectId The ID of the project containing the label.
+     * @param name The name of the label to delete.
+     * @throws IOException
+     */
+    public void deleteLabel(Serializable projectId, String name)
+            throws IOException {
+        Query query = new Query();
+        query.append("name", name);
+        String tailUrl = GitlabProject.URL + "/" +
+                projectId +
+                GitlabLabel.URL +
+                query.toString();
+        retrieve().method("DELETE").to(tailUrl, Void.class);
+    }
+
+    /**
+     * Deletes an existing label.
+     * @param projectId The ID of the project containing the label.
+     * @param label The label to delete.
+     * @throws IOException
+     */
+    public void deleteLabel(Serializable projectId, GitlabLabel label)
+            throws IOException {
+        deleteLabel(projectId, label.getName());
+    }
+
+    /**
+     * Updates an existing label.
+     * @param projectId The ID of the project containing the label.
+     * @param name The name of the label to update.
+     * @param newName The updated name.
+     * @param newColor The updated color.
+     * @return The updated, deserialized label.
+     * @throws IOException
+     */
+    public GitlabLabel updateLabel(Serializable projectId,
+                                   String name,
+                                   String newName,
+                                   String newColor) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + projectId + GitlabLabel.URL;
+        GitlabHTTPRequestor requestor = retrieve().method("PUT");
+        requestor.with("name", name);
+        if (newName != null) {
+            requestor.with("new_name", newName);
+        }
+        if (newColor != null) {
+            requestor = requestor.with("color", newColor);
+        }
+        return requestor.to(tailUrl, GitlabLabel.class);
+    }
+
     public List<GitlabMilestone> getMilestones(GitlabProject project) throws IOException {
         return getMilestones(String.valueOf(project.getId()));
     }

--- a/src/main/java/org/gitlab/api/models/GitlabLabel.java
+++ b/src/main/java/org/gitlab/api/models/GitlabLabel.java
@@ -1,0 +1,45 @@
+package org.gitlab.api.models;
+
+/**
+ * Models a Gitlab label.
+ */
+public class GitlabLabel {
+
+    public static final String URL = "/labels";
+
+    private String name;
+    private String color;
+
+    /**
+     * Gets the name (text) of a label.
+     * @return
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name (text) of a label.
+     * @param name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the color of a label as six digit HTML hex value.
+     * @return
+     */
+    public String getColor() {
+        return color;
+    }
+
+    /**
+     * Sets the color of a label.
+     * @param color A six digit HTML hex value including number sign (eg #ff0000)
+     */
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+}


### PR DESCRIPTION
### Purpose
Wraps "POST", "GET", "PUT" and "DELETE" HTTP verbs for api version 3.

### Files Updated
* src/main/java/org/gitlab/api/GitlabAPI.java
    * Added overloaded methods to get labels by project.
    * Added overloaded methods to create new labels.
    * Added overloaded methods to delete an existing label
    * Added a single method to update an existing label
*  src/main/java/org/gitlab/api/models/GitlabLabel.java
    * Created a new type which models a Gitlab label.

### Notes
If you're interested in this PR and would like any changes, please do let me know and I'll be happy to oblige.