### PR TITLE
Code Quality Improvement - @Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -191,6 +191,7 @@ public class GitlabHTTPRequestor {
                 }
             }
 
+            @Override
             public boolean hasNext() {
                 fetch();
                 if (next != null && next.getClass().isArray()) {
@@ -201,6 +202,7 @@ public class GitlabHTTPRequestor {
                 }
             }
 
+            @Override
             public T next() {
                 fetch();
                 T record = next;
@@ -213,6 +215,7 @@ public class GitlabHTTPRequestor {
                 return record;
             }
 
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }
@@ -367,14 +370,17 @@ public class GitlabHTTPRequestor {
     private void ignoreCertificateErrors() {
         TrustManager[] trustAllCerts = new TrustManager[]{
                 new X509TrustManager() {
+                    @Override
                     public java.security.cert.X509Certificate[] getAcceptedIssuers() {
                         return null;
                     }
 
+                    @Override
                     public void checkClientTrusted(
                             java.security.cert.X509Certificate[] certs, String authType) {
                     }
 
+                    @Override
                     public void checkServerTrusted(
                             java.security.cert.X509Certificate[] certs, String authType) {
                     }

--- a/src/main/java/org/gitlab/api/models/GitlabSession.java
+++ b/src/main/java/org/gitlab/api/models/GitlabSession.java
@@ -9,10 +9,12 @@ public class GitlabSession extends GitlabUser {
     @JsonProperty("private_token")
     private String privateToken;
 
+    @Override
     public String getPrivateToken() {
         return privateToken;
     }
 
+    @Override
     public void setPrivateToken(String privateToken) {
         this.privateToken = privateToken;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1161 - @Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1161.

Please let me know if you have any questions.

Christian