### PR TITLE
post 'line_type' parameter to gitlab when creating a commit comment

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1687,7 +1687,8 @@ public class GitlabAPI {
     			.appendIf("sha", sha)
     			.appendIf("note", note)
     			.appendIf("path", path)
-    			.appendIf("line", line);
+    			.appendIf("line", line)
+    			.appendIf("line_type", line_type);
     	String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/repository/commits/" + sha + CommitComment.URL + query.toString();
     
     	return dispatch().to(tailUrl, CommitComment.class);


### PR DESCRIPTION
So that GitLab can link the comment to the specified line of the specified path...