### PR TITLE
[Enhancement] Add IDE plugins to build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target
 .classpath
 .project
 .settings
+*.ipr
+*.iws

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,10 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'maven'
 
+// IDE plugins
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 


### PR DESCRIPTION
I wanted to use this library, so I wanted to get started by looking at the source code. I noticed that the gradle IDE plugins were not included in the build file. Since there's almost no overhead having the plugins included in the build script and makes it easier for anyone to get started by generating the IDE files from command line, I've added it.