### PR TITLE
Added getBuildsArtifact method

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -613,6 +613,29 @@ public class GitlabAPI {
 
 
     /**
+     * Get build artifacts of a project build
+     *
+     * @param project The Project
+     * @param build The build
+     * @throws IOException on gitlab api call error
+     */
+    public byte[] getBuildArtifact(GitlabProject project, GitlabBuild build) throws IOException {
+        return getBuildArtifact(project.getId(), build.getId());
+    }
+
+    /**
+     * Get build artifacts of a project build
+     *
+     * @param projectId The Project's Id
+     * @param buildId The build's Id
+     * @throws IOException on gitlab api call error
+     */
+    public byte[] getBuildArtifact(Integer projectId, Integer buildId) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabBuild.URL + "/" + buildId + "/artifacts";
+        return retrieve().to(tailUrl, byte[].class);
+    }
+
+    /**
      * Creates a private Project
      *
      * @param name The name of the project

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -322,7 +322,7 @@ public class GitlabHTTPRequestor {
         InputStreamReader reader = null;
         try {
             if (byte[].class == type) {
-                return type.cast(IOUtils.toByteArray(connection.getInputStream()));
+                return type.cast(IOUtils.toByteArray(wrapStream(connection, connection.getInputStream())));
             }
             reader = new InputStreamReader(wrapStream(connection, connection.getInputStream()), "UTF-8");
             String data = IOUtils.toString(reader);

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -321,10 +321,10 @@ public class GitlabHTTPRequestor {
     private <T> T parse(HttpURLConnection connection, Class<T> type, T instance) throws IOException {
         InputStreamReader reader = null;
         try {
-            reader = new InputStreamReader(wrapStream(connection, connection.getInputStream()), "UTF-8");
             if (byte[].class == type) {
-            	return type.cast(IOUtils.toByteArray(reader));
+                return type.cast(IOUtils.toByteArray(connection.getInputStream()));
             }
+            reader = new InputStreamReader(wrapStream(connection, connection.getInputStream()), "UTF-8");
             String data = IOUtils.toString(reader);
             if (type != null) {
                 return GitlabAPI.MAPPER.readValue(data, type);


### PR DESCRIPTION
See [the API docs for the method](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/builds.md#get-build-artifacts)

I ran into an odd issue where the download files were 10MB too big
and were in an invalid .tgz format, but reading the byte stream
from the actual input stream instead of the reader fixed the issue.

I don't know if it was broken from #69 or if it's a change in gitlab?