### PR TITLE
Added a null check to GitlabGroup#setLdapAccess. 

### DIFF
--- a/src/main/java/org/gitlab/api/models/GitlabGroup.java
+++ b/src/main/java/org/gitlab/api/models/GitlabGroup.java
@@ -53,6 +53,8 @@ public class GitlabGroup {
     }
 
     public void setLdapAccess(GitlabAccessLevel ldapGitlabAccessLevel) {
-       this.ldapAccess = ldapGitlabAccessLevel.accessValue;
+        if (ldapGitlabAccessLevel != null) {
+            this.ldapAccess = ldapGitlabAccessLevel.accessValue;
+        }
     }
 }

--- a/src/test/java/org/gitlab/api/models/GitlabGroupTest.java
+++ b/src/test/java/org/gitlab/api/models/GitlabGroupTest.java
@@ -1,0 +1,16 @@
+package org.gitlab.api.models;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link GitlabGroup}
+ */
+public class GitlabGroupTest {
+
+    @Test
+    public void setLdapAccessHandlesNull() {
+        GitlabGroup group = new GitlabGroup();
+        group.setLdapAccess(null);
+    }
+
+}


### PR DESCRIPTION
This resolves a NullPointerException that was encountered when unmarshalling a a GitlabGroup JSON object with a null ldap_access attribute.

Fixes #117 