### PR TITLE
Add get group by path

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -343,7 +343,18 @@ public class GitlabAPI {
     }
 
     public GitlabGroup getGroup(Integer groupId) throws IOException {
-        String tailUrl = GitlabGroup.URL + "/" + groupId;
+        return getGroup(groupId.toString());
+    }
+
+    /**
+     * Get a group by path
+     *
+     * @param path Path of the group
+     * @return
+     * @throws IOException
+     */
+    public GitlabGroup getGroup(String path) throws IOException {
+        String tailUrl = GitlabGroup.URL + "/" + path;
         return retrieve().to(tailUrl, GitlabGroup.class);
     }
 

--- a/src/test/java/org/gitlab/api/GitlabAPITest.java
+++ b/src/test/java/org/gitlab/api/GitlabAPITest.java
@@ -1,5 +1,6 @@
 package org.gitlab.api;
 
+import org.gitlab.api.models.GitlabGroup;
 import org.gitlab.api.models.GitlabUser;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -117,6 +118,27 @@ public class GitlabAPITest {
         }
 
 
+    }
+
+    @Test
+    public void testGetGroupByPath() throws IOException {
+        // Given
+        String name = "groupName";
+        String path = "groupPath";
+
+        GitlabGroup originalGroup = api.createGroup(name, path);
+
+        // When
+        GitlabGroup group = api.getGroup(path);
+
+        // Then:
+        assertNotNull(group);
+        assertEquals(originalGroup.getId(), group.getId());
+        assertEquals(originalGroup.getName(), group.getName());
+        assertEquals(originalGroup.getPath(), group.getPath());
+
+        // Cleanup
+        api.deleteGroup(group.getId());
     }
 
     private String randVal(String postfix) {


### PR DESCRIPTION
Add get group by path.

According to the [API Documentation](http://docs.gitlab.com/ce/api/groups.html#details-of-a-group) the parameter ``id`` of the endpoint ``GET /groups/:id`` can be ``The ID or path of a group``.
