### PR TITLE
Deprecating the parameter versions of the createProject, updateProject and createUserProject calls

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -688,6 +688,7 @@ public class GitlabAPI {
      * @return the Gitlab Project
      * @throws IOException on gitlab api call error
      */
+    @Deprecated
     public GitlabProject createProject(String name, Integer namespaceId, String description, Boolean issuesEnabled, Boolean wallEnabled, Boolean mergeRequestsEnabled, Boolean wikiEnabled, Boolean snippetsEnabled, Boolean publik, Integer visibilityLevel, String importUrl) throws IOException {
         Query query = new Query()
                 .append("name", name)
@@ -737,6 +738,7 @@ public class GitlabAPI {
      * @return The GitLab Project
      * @throws IOException on gitlab api call error
      */
+    @Deprecated
     public GitlabProject createUserProject(Integer userId, String name, String description, String defaultBranch, Boolean issuesEnabled, Boolean wallEnabled, Boolean mergeRequestsEnabled, Boolean wikiEnabled, Boolean snippetsEnabled, Boolean publik, Integer visibilityLevel, String importUrl) throws IOException {
         Query query = new Query()
                 .append("name", name)
@@ -773,6 +775,7 @@ public class GitlabAPI {
      * @return the Gitlab Project
      * @throws IOException on gitlab api call error
      */
+    @Deprecated
     public GitlabProject updateProject(
             Integer projectId,
             String  name,


### PR DESCRIPTION
Separate pull request for marking them deprecated incase you agree. Should merge in fine before or after the other one I tested it locally.