### PR TITLE
Add List of identities under GitlabUser

### DIFF
--- a/src/main/java/org/gitlab/api/models/GitlabUser.java
+++ b/src/main/java/org/gitlab/api/models/GitlabUser.java
@@ -1,6 +1,7 @@
 package org.gitlab.api.models;
 
 import java.util.Date;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -22,6 +23,7 @@ public class GitlabUser {
     private String _provider;
     private String _state;
     private boolean _blocked;
+    private List<GitlabUserIdentity> _identities;
 
     @JsonProperty("private_token")
     private String _privateToken;
@@ -288,5 +290,13 @@ public class GitlabUser {
 
     public void setProjectsLimit(Integer projectsLimit) {
         this._projectsLimit = projectsLimit;
+    }
+
+    public List<GitlabUserIdentity> getIdentities() {
+        return _identities;
+    }
+
+    public void setIdentities(List<GitlabUserIdentity> identities) {
+        this._identities = identities;
     }
 }

--- a/src/main/java/org/gitlab/api/models/GitlabUserIdentity.java
+++ b/src/main/java/org/gitlab/api/models/GitlabUserIdentity.java
@@ -7,8 +7,8 @@ public class GitlabUserIdentity {
     @JsonProperty("provider")
     private String _provider;
 
-    @JsonProperty("extern_uuid")
-    private String _externUuid;
+    @JsonProperty("extern_uid")
+    private String _externUid;
 
     public String getProvider() {
         return _provider;
@@ -18,11 +18,11 @@ public class GitlabUserIdentity {
         this._provider = provider;
     }
 
-    public String getExternUuid() {
-        return _externUuid;
+    public String getExternUid() {
+        return _externUid;
     }
 
-    public void setExternUuid(String externUuid) {
-        this._externUuid = externUuid;
+    public void setExternUuid(String externUid) {
+        this._externUid = externUid;
     }
 }

--- a/src/main/java/org/gitlab/api/models/GitlabUserIdentity.java
+++ b/src/main/java/org/gitlab/api/models/GitlabUserIdentity.java
@@ -1,0 +1,28 @@
+package org.gitlab.api.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitlabUserIdentity {
+
+    @JsonProperty("provider")
+    private String _provider;
+
+    @JsonProperty("extern_uuid")
+    private String _externUuid;
+
+    public String getProvider() {
+        return _provider;
+    }
+
+    public void setProvider(String provider) {
+        this._provider = provider;
+    }
+
+    public String getExternUuid() {
+        return _externUuid;
+    }
+
+    public void setExternUuid(String externUuid) {
+        this._externUuid = externUuid;
+    }
+}


### PR DESCRIPTION
This pull request will add the identities-property as a List. Currently the library would return the provider and extern_uid directly from the user object. These are always empty and this is the solution because the keys are in the list of identities.

See: https://docs.gitlab.com/ce/api/users.html#for-admin