### PR TITLE
Add support for projects shared with a group.

### DIFF
--- a/src/main/java/org/gitlab/api/models/GitlabGroup.java
+++ b/src/main/java/org/gitlab/api/models/GitlabGroup.java
@@ -2,6 +2,8 @@ package org.gitlab.api.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public class GitlabGroup {
 
     public static final String URL = "/groups";
@@ -15,6 +17,9 @@ public class GitlabGroup {
 
     @JsonProperty("ldap_access")
     private Integer ldapAccess;
+
+    @JsonProperty("shared_projects")
+    private List<GitlabProject> sharedProjects;
 
     public Integer getId() {
         return id;
@@ -59,5 +64,13 @@ public class GitlabGroup {
         if (ldapGitlabAccessLevel != null) {
             this.ldapAccess = ldapGitlabAccessLevel.accessValue;
         }
+    }
+
+    public List<GitlabProject> getSharedProjects() {
+        return sharedProjects;
+    }
+
+    public void setSharedProjects(List<GitlabProject> sharedProjects) {
+        this.sharedProjects = sharedProjects;
     }
 }

--- a/src/main/java/org/gitlab/api/models/GitlabProject.java
+++ b/src/main/java/org/gitlab/api/models/GitlabProject.java
@@ -95,6 +95,9 @@ public class GitlabProject {
     @JsonProperty("tag_list")
     private List<String> tagList;
 
+    @JsonProperty("shared_with_groups")
+    private List<GitlabProjectSharedGroup> sharedWithGroups;
+
     public Integer getId() {
         return id;
     }
@@ -349,5 +352,13 @@ public class GitlabProject {
 
     public void setTagList(List<String> tagList) {
         this.tagList = tagList;
+    }
+
+    public List<GitlabProjectSharedGroup> getSharedWithGroups() {
+        return sharedWithGroups;
+    }
+
+    public void setSharedWithGroups(List<GitlabProjectSharedGroup> sharedWithGroups) {
+        this.sharedWithGroups = sharedWithGroups;
     }
 }

--- a/src/main/java/org/gitlab/api/models/GitlabProjectSharedGroup.java
+++ b/src/main/java/org/gitlab/api/models/GitlabProjectSharedGroup.java
@@ -1,0 +1,38 @@
+package org.gitlab.api.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitlabProjectSharedGroup {
+    @JsonProperty("group_id")
+    private int groupId;
+
+    @JsonProperty("group_name")
+    private String groupName;
+
+    @JsonProperty("group_access_level")
+    private int groupAccessLevel;
+
+    public int getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(int groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public GitlabAccessLevel getAccessLevel() {
+        return GitlabAccessLevel.fromAccessValue(groupAccessLevel);
+    }
+
+    public void setAccessLevel(GitlabAccessLevel accessLevel) {
+        this.groupAccessLevel = accessLevel.accessValue;
+    }
+}


### PR DESCRIPTION
This merge request adds support to list all projects that are shared with a group to the `GitlabGroup` object. This is accessible with `GitlabGroup.getSharedProjects()`.

Also, created a new `GitlabProjectSharedGroup` class to represent the relationship of a project being shared with a group since the [API exposes limited information](https://docs.gitlab.com/ee/api/projects.html#get-single-project) about the group in the project's `shared_with_groups` property. This is accessible with `GitlabProject.getSharedWithGroups()`. If someone wants more information about the group, then they'll have to use `GitlabAPI.getGroup()` to get the details of that group.