### PR TITLE
Add getProject method via namespace and project name

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1,10 +1,12 @@
 package org.gitlab.api;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.gitlab.api.http.GitlabHTTPRequestor;
+import org.gitlab.api.http.Query;
+import org.gitlab.api.models.*;
+
+import java.io.*;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
@@ -12,20 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-
-import org.gitlab.api.http.GitlabHTTPRequestor;
-import org.gitlab.api.http.Query;
-import org.gitlab.api.models.*;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.gitlab.api.http.GitlabHTTPRequestor;
-import org.gitlab.api.http.Query;
-import org.gitlab.api.models.*;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 /**
@@ -578,6 +566,14 @@ public class GitlabAPI {
 
     public GitlabProject getProject(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId);
+        return retrieve().to(tailUrl, GitlabProject.class);
+    }
+
+    /**
+     * use namespace & project name to get project
+     */
+    public GitlabProject getProject(String namespace, String projectName) throws IOException{
+        String tailUrl = GitlabProject.URL + "/" + namespace + "%2F" + projectName;
         return retrieve().to(tailUrl, GitlabProject.class);
     }
 


### PR DESCRIPTION
Cause project id is not so easy to get, I think it is necessary to add a method to get a project using namespace and project name.
Referenced Gitlab API:  
```
Get single project 

Get a specific project, identified by project ID or NAMESPACE/PROJECT_NAME, which is owned by the authenticated user. If using namespaced projects call make sure that the NAMESPACE/PROJECT_NAME is URL-encoded, eg. /api/v3/projects/diaspora%2Fdiaspora (where / is represented by %2F). This endpoint can be accessed without authentication if the project is publicly accessible.
```

ps. It is my first time to do a pull request, if I did anything wrong plz tell me.