### PR TITLE
GitlabAPI#getGroupProjects() retrieve all projects from the group

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -405,7 +405,7 @@ public class GitlabAPI {
      */
     public List<GitlabProject> getGroupProjects(Integer groupId) throws IOException {
         String tailUrl = GitlabGroup.URL + "/" + groupId + GitlabProject.URL;
-        return Arrays.asList(retrieve().to(tailUrl, GitlabProject[].class));
+        return retrieve().getAll(tailUrl, GitlabProject[].class);
     }
 
     /**


### PR DESCRIPTION
Until now, the `GitlabAPI#getGroupProjects()`list only the first 20 projects in a group.

-----

### Workaround

```java
final GitlabGroup group = gitlabAPI.getGroup(".....");
final String tailUrl = GitlabGroup.URL + "/" + group.getId() + GitlabProject.URL;
final List<GitlabProject> projects = gitlabAPI.retrieve().getAll(tailUrl, GitlabProject[].class);
```