### PR TITLE
Handle 204 response

### DIFF
--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -393,7 +393,7 @@ public class GitlabHTTPRequestor {
             }
             reader = new InputStreamReader(wrapStream(connection, connection.getInputStream()), "UTF-8");
             String data = IOUtils.toString(reader);
-            if (type != null) {
+            if (type != null && type != Void.class) {
                 return GitlabAPI.MAPPER.readValue(data, type);
             } else if (instance != null) {
                 return GitlabAPI.MAPPER.readerForUpdating(instance).readValue(data);

--- a/src/test/java/org/gitlab/api/GitlabAPITest.java
+++ b/src/test/java/org/gitlab/api/GitlabAPITest.java
@@ -123,7 +123,7 @@ public class GitlabAPITest {
                 randVal("userName"),
                 randVal("fullName"),
                 randVal("skypeId"),
-                randVal("linledin"),
+                randVal("linkedin"),
                 randVal("twitter"),
                 "http://" + randVal("url.com"),
                 10,


### PR DESCRIPTION
Fixes https://github.com/timols/java-gitlab-api/issues/202

Simplest solution is to not attempt to map to the Void class that appears to be passed in for all of the DELETE based operations.

Additionally, I fixed a minor typo in the GitlabAPITest class.