### PR TITLE
fixes getProjects(namespace, name) with a search

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -585,8 +585,15 @@ public class GitlabAPI {
      * use namespace & project name to get project
      */
     public GitlabProject getProject(String namespace, String projectName) throws IOException{
-        String tailUrl = GitlabProject.URL + "/" + namespace + "%2F" + projectName;
-        return retrieve().to(tailUrl, GitlabProject.class);
+        String fullName = namespace+" / "+projectName;
+        String tailUrl = GitlabProject.URL + "?search=" + projectName;
+        GitlabProject[] projects = retrieve().to(tailUrl, GitlabProject[].class);
+        for(GitlabProject gp : projects) {
+            if(gp.getNameWithNamespace().equals(fullName)) {
+                return gp;
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Hello,

Here is a little contribution to fix the `getProject(String namespace, String projectName)` method, because in the Gitlab API, you can only access a project by its ID. Hence you need to do a search and compare it with retrieved projects.

Any feedback is welcomed :-)

Best regards,
Cédric