### PR TITLE
Improvement of getMergedRequest methods and new cherryPick method

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -921,6 +921,28 @@ public class GitlabAPI {
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
 
+    public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String status) throws IOException {
+        return getMergeRequestsWithStatus(projectId, status, new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE));
+    }
+    
+    public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String status, Pagination pagination) throws IOException {
+        Query query = pagination.asQuery();
+        query.append("state", status);
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + query;
+        return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
+    }
+    
+    public List<GitlabMergeRequest> getMergeRequestsWithStatus(GitlabProject project, String status) throws IOException {
+        return getMergeRequestsWithStatus(project, status, new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE));
+    }
+    
+    public List<GitlabMergeRequest> getMergeRequestsWithStatus(GitlabProject project, String status, Pagination pagination) throws IOException {
+        Query query = pagination.asQuery();
+        query.append("state", status);
+        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + query;
+        return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
+    }
+    
     public List<GitlabMergeRequest> getMergeRequests(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1012,15 +1012,13 @@ public class GitlabAPI {
      * @throws IOException on gitlab api call error
      */
     public GitlabCommit cherryPick(Serializable projectId, String sha, String targetBranchName) throws IOException {
-        Query query = new Query().append("branch", targetBranchName);
-        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/respository/commits/" + sha + "/cherry_pick" + query.toString();
-        return retrieve().to(tailUrl, GitlabCommit.class);
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/repository/commits/" + sha + "/cherry_pick";
+        return retrieve().with("branch", targetBranchName).to(tailUrl, GitlabCommit.class);
     }
     
     public GitlabCommit cherryPick(GitlabProject project, String sha, String targetBranchName) throws IOException {
-        Query query = new Query().append("branch", targetBranchName);
-        String tailUrl = GitlabProject.URL + "/" + project.getId() + "/respository/commits/" + sha + "/cherry_pick" + query.toString();
-        return retrieve().to(tailUrl, GitlabCommit.class);
+        String tailUrl = GitlabProject.URL + "/" + project.getId() + "/repository/commits/" + sha + "/cherry_pick";
+        return dispatch().with("branch", targetBranchName).to(tailUrl, GitlabCommit.class);
     }
     
     /**

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1002,9 +1002,24 @@ public class GitlabAPI {
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
 
+    /**
+     * Cherry picks a commit.
+     * 
+     * @param projectId         The id of the project
+     * @param sha               The sha of the commit
+     * @param targetBranchName  The branch on which the commit must be cherry-picked
+     * @return the commit of the cherry-pick.
+     * @throws IOException on gitlab api call error
+     */
     public GitlabCommit cherryPick(Serializable projectId, String sha, String targetBranchName) throws IOException {
         Query query = new Query().append("branch", targetBranchName);
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/respository/commits/" + sha + "/cherry_pick" + query.toString();
+        return retrieve().to(tailUrl, GitlabCommit.class);
+    }
+    
+    public GitlabCommit cherryPick(GitlabProject project, String sha, String targetBranchName) throws IOException {
+        Query query = new Query().append("branch", targetBranchName);
+        String tailUrl = GitlabProject.URL + "/" + project.getId() + "/respository/commits/" + sha + "/cherry_pick" + query.toString();
         return retrieve().to(tailUrl, GitlabCommit.class);
     }
     

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1002,6 +1002,12 @@ public class GitlabAPI {
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
 
+    public GitlabCommit cherryPick(Serializable projectId, String sha, String targetBranchName) throws IOException {
+        Query query = new Query().append("branch", targetBranchName);
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/respository/commits/" + sha + "/cherry_pick" + query.toString();
+        return retrieve().to(tailUrl, GitlabCommit.class);
+    }
+    
     /**
      * Return Merge Request.
      *

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -908,51 +908,51 @@ public class GitlabAPI {
     }
 
     public List<GitlabMergeRequest> getOpenMergeRequests(Serializable projectId) throws IOException {
-        return getMergeRequestsWithStatus(projectId, "opened");
+        return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_OPENED);
     }
     
     public List<GitlabMergeRequest> getOpenMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
-        return getMergeRequestsWithStatus(projectId, "opened", pagination);
+        return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_OPENED, pagination);
     }
 
     public List<GitlabMergeRequest> getOpenMergeRequests(GitlabProject project) throws IOException {
-        return getMergeRequestsWithStatus(project, "opened");
+        return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_OPENED);
     }
     
     public List<GitlabMergeRequest> getOpenMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
-        return getMergeRequestsWithStatus(project, "opened", pagination);
+        return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_OPENED, pagination);
     }
     
     public List<GitlabMergeRequest> getMergedMergeRequests(Serializable projectId) throws IOException {
-        return getMergeRequestsWithStatus(projectId, "merged");
+        return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_MERGED);
     }
     
     public List<GitlabMergeRequest> getMergedMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
-        return getMergeRequestsWithStatus(projectId, "merged", pagination);
+        return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_MERGED, pagination);
     }
 
     public List<GitlabMergeRequest> getMergedMergeRequests(GitlabProject project) throws IOException {
-        return getMergeRequestsWithStatus(project, "merged");
+        return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_MERGED);
     }
     
     public List<GitlabMergeRequest> getMergedMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
-        return getMergeRequestsWithStatus(project, "merged", pagination);
+        return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_MERGED, pagination);
     }
     
     public List<GitlabMergeRequest> getClosedMergeRequests(Serializable projectId) throws IOException {
-        return getMergeRequestsWithStatus(projectId, "closed");
+        return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_CLOSED);
     }
     
     public List<GitlabMergeRequest> getClosedMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
-        return getMergeRequestsWithStatus(projectId, "closed", pagination);
+        return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_CLOSED, pagination);
     }
 
     public List<GitlabMergeRequest> getClosedMergeRequests(GitlabProject project) throws IOException {
-        return getMergeRequestsWithStatus(project, "closed");
+        return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_CLOSED);
     }
     
     public List<GitlabMergeRequest> getClosedMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
-        return getMergeRequestsWithStatus(project, "closed", pagination);
+        return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_CLOSED, pagination);
     }
 
     public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String status) throws IOException {

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -908,26 +908,60 @@ public class GitlabAPI {
     }
 
     public List<GitlabMergeRequest> getOpenMergeRequests(Serializable projectId) throws IOException {
-        Query query = new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery();
-        query.append("state", "opened");
-        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + query;
-        return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
+        return getMergeRequestsWithStatus(projectId, "opened");
+    }
+    
+    public List<GitlabMergeRequest> getOpenMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
+        return getMergeRequestsWithStatus(projectId, "opened", pagination);
     }
 
     public List<GitlabMergeRequest> getOpenMergeRequests(GitlabProject project) throws IOException {
-        Query query = new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery();
-        query.append("state", "opened");
-        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + query;
-        return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
+        return getMergeRequestsWithStatus(project, "opened");
+    }
+    
+    public List<GitlabMergeRequest> getOpenMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
+        return getMergeRequestsWithStatus(project, "opened", pagination);
+    }
+    
+    public List<GitlabMergeRequest> getMergedMergeRequests(Serializable projectId) throws IOException {
+        return getMergeRequestsWithStatus(projectId, "merged");
+    }
+    
+    public List<GitlabMergeRequest> getMergedMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
+        return getMergeRequestsWithStatus(projectId, "merged", pagination);
+    }
+
+    public List<GitlabMergeRequest> getMergedMergeRequests(GitlabProject project) throws IOException {
+        return getMergeRequestsWithStatus(project, "merged");
+    }
+    
+    public List<GitlabMergeRequest> getMergedMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
+        return getMergeRequestsWithStatus(project, "merged", pagination);
+    }
+    
+    public List<GitlabMergeRequest> getClosedMergeRequests(Serializable projectId) throws IOException {
+        return getMergeRequestsWithStatus(projectId, "closed");
+    }
+    
+    public List<GitlabMergeRequest> getClosedMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
+        return getMergeRequestsWithStatus(projectId, "closed", pagination);
+    }
+
+    public List<GitlabMergeRequest> getClosedMergeRequests(GitlabProject project) throws IOException {
+        return getMergeRequestsWithStatus(project, "closed");
+    }
+    
+    public List<GitlabMergeRequest> getClosedMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
+        return getMergeRequestsWithStatus(project, "closed", pagination);
     }
 
     public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String status) throws IOException {
         return getMergeRequestsWithStatus(projectId, status, new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE));
     }
     
-    public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String status, Pagination pagination) throws IOException {
+    public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String state, Pagination pagination) throws IOException {
         Query query = pagination.asQuery();
-        query.append("state", status);
+        query.append("state", state);
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + query;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
@@ -936,9 +970,9 @@ public class GitlabAPI {
         return getMergeRequestsWithStatus(project, status, new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE));
     }
     
-    public List<GitlabMergeRequest> getMergeRequestsWithStatus(GitlabProject project, String status, Pagination pagination) throws IOException {
+    public List<GitlabMergeRequest> getMergeRequestsWithStatus(GitlabProject project, String state, Pagination pagination) throws IOException {
         Query query = pagination.asQuery();
-        query.append("state", status);
+        query.append("state", state);
         String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + query;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
@@ -947,14 +981,24 @@ public class GitlabAPI {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
+    
+    public List<GitlabMergeRequest> getMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + pagination.toString();
+        return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
+    }
 
     public List<GitlabMergeRequest> getMergeRequests(GitlabProject project) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
+    
+    public List<GitlabMergeRequest> getMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + pagination.toString();
+        return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
+    }
 
     public List<GitlabMergeRequest> getAllMergeRequests(GitlabProject project) throws IOException {
-        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + PARAM_MAX_ITEMS_PER_PAGE;
+        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
 

--- a/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
@@ -7,7 +7,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabMergeRequest {
     public static final String URL = "/merge_requests";
-
+    public static final String STATUS_OPENED = "opened";
+    public static final String STATUS_MERGED = "merged";
+    public static final String STATUS_CLOSED = "closed";
+    
     private Integer id;
     private Integer iid;
     private String title;


### PR DESCRIPTION
Hello,

I just submit some improvements in the GitlabAPI interface:
- new methods `getMergedMergeRequests`
- new methods `getClosedMergeRequests`
- new methods `getMergeRequestWithStatus`
- new methods `cherryPick`
- handling `Pagination` on MergeRequest methods
- removed pagination limit in `getAllMergeRequests`
- minor refactorisation of `getMergeRequests` methods

Let me know if this is valuable enough to be merged :-)

Best regards,
Cédric