### PR TITLE
Support creation of subgroups

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -488,6 +488,35 @@ public class GitlabAPI {
     /**
      * Creates a Group
      *
+     * @param request  The project-creation request
+     * @param sudoUser The user to create the group on behalf of
+     *
+     * @return The GitLab Group
+     * @throws IOException on gitlab api call error
+     */
+    public GitlabGroup createGroup(CreateGroupRequest request, GitlabUser sudoUser) throws IOException {
+
+        Query query = new Query()
+                .append("name", request.getName())
+                .append("path", request.getPath())
+                .appendIf("ldap_cn", request.getLdapCn())
+                .appendIf("description", request.getDescription())
+                .appendIf("membershipLock", request.getMembershipLock())
+                .appendIf("share_with_group_lock", request.getShareWithGroupLock())
+                .appendIf("visibility", request.getVisibility())
+                .appendIf("lfs_enabled", request.getLfsEnabled())
+                .appendIf("request_access_enabled", request.getRequestAccessEnabled())
+                .appendIf("parent_id", request.getParentId())
+                .appendIf(PARAM_SUDO, sudoUser != null ? sudoUser.getId() : null);
+
+        String tailUrl = GitlabGroup.URL + query.toString();
+
+        return dispatch().to(tailUrl, GitlabGroup.class);
+    }
+
+    /**
+     * Creates a Group
+     *
      * @param name       The name of the group
      * @param path       The path for the group
      * @param ldapCn     LDAP Group Name to sync with, null otherwise

--- a/src/main/java/org/gitlab/api/models/CreateGroupRequest.java
+++ b/src/main/java/org/gitlab/api/models/CreateGroupRequest.java
@@ -1,0 +1,114 @@
+package org.gitlab.api.models;
+
+
+public class CreateGroupRequest {
+
+    public CreateGroupRequest(String name) {
+	this(name, name);
+    }
+
+    public CreateGroupRequest(String name, String path) {
+	this.name = name;
+	this.path = path;
+    }
+
+    private String name;
+    private String path;
+    private String ldapCn;
+    private String description;
+    private Boolean membershipLock;
+    private Boolean shareWithGroupLock;
+    private Boolean visibility;
+    private Boolean lfsEnabled;
+    private Boolean requestAccessEnabled;
+    private Integer parentId;
+
+    public String getName() {
+        return name;
+    }
+
+    public CreateGroupRequest setName(String name) {
+        this.name = name;
+        return this;
+    }
+    public String getPath() {
+        return path;
+    }
+
+    public CreateGroupRequest setPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public String getLdapCn() {
+        return ldapCn;
+    }
+
+    public CreateGroupRequest setLdapCn(String ldapCn) {
+        this.ldapCn = ldapCn;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public CreateGroupRequest setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public Boolean getMembershipLock() {
+        return membershipLock;
+    }
+
+    public CreateGroupRequest setMembershipLock(Boolean membershipLock) {
+        this.membershipLock = membershipLock;
+        return this;
+    }
+
+    public Boolean getShareWithGroupLock() {
+        return shareWithGroupLock;
+    }
+
+    public CreateGroupRequest setShareWithGroupLock(Boolean shareWithGroupLock) {
+        this.shareWithGroupLock = shareWithGroupLock;
+        return this;
+    }
+
+    public Boolean getVisibility() {
+        return visibility;
+    }
+
+    public CreateGroupRequest setVisibility(Boolean visibility) {
+        this.visibility = visibility;
+        return this;
+    }
+
+    public Boolean getLfsEnabled() {
+        return lfsEnabled;
+    }
+
+    public CreateGroupRequest setLfsEnabled(Boolean lfsEnabled) {
+        this.lfsEnabled = lfsEnabled;
+        return this;
+    }
+
+    public Boolean getRequestAccessEnabled() {
+        return requestAccessEnabled;
+    }
+
+    public CreateGroupRequest setRequestAccessEnabled(Boolean requestAccessEnabled) {
+        this.requestAccessEnabled = requestAccessEnabled;
+        return this;
+    }
+
+    public Integer getParentId() {
+        return parentId;
+    }
+
+    public CreateGroupRequest setParentId(Integer parentId) {
+        this.parentId = parentId;
+        return this;
+    }
+}

--- a/src/main/java/org/gitlab/api/models/GitlabGroup.java
+++ b/src/main/java/org/gitlab/api/models/GitlabGroup.java
@@ -24,12 +24,23 @@ public class GitlabGroup {
     @JsonProperty("web_url")
     private String webUrl;
 
+    @JsonProperty("parent_id")
+    private Integer parentId;
+
     public Integer getId() {
         return id;
     }
 
+    public Integer getParentId() {
+        return parentId;
+    }
+
     public void setId(Integer id) {
         this.id = id;
+    }
+
+    public void setParentId(Integer parentId) {
+        this.parentId = parentId;
     }
 
     public String getName() {


### PR DESCRIPTION
... and every other group creation option that is presently documented.

I decided not to add more parameters to the existing methods, because they were getting unwieldy. 

I've manually tested this on our Gitlab 9.0.x instance and it appears to work.