### PR TITLE
RepositoryTree, Branches, and Tags lists are paginated in the v4 api.

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1440,7 +1440,7 @@ public class GitlabAPI {
      * @throws IOException on gitlab api call error
      */
     public List<GitlabRepositoryTree> getRepositoryTree(GitlabProject project, String path, String ref, boolean recursive) throws IOException {
-        Query query = new Query()
+        Query query = new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery()
                 .appendIf("path", path)
                 .appendIf("ref", ref)
                 .appendIf("recursive", recursive);
@@ -1563,12 +1563,12 @@ public class GitlabAPI {
 	}
 
     public List<GitlabBranch> getBranches(Serializable projectId) throws IOException {
-        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabBranch.URL;
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabBranch.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabBranch[].class);
     }
 
     public List<GitlabBranch> getBranches(GitlabProject project) throws IOException {
-        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabBranch.URL;
+        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabBranch.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabBranch[].class);
     }
 
@@ -2331,7 +2331,7 @@ public class GitlabAPI {
      * @throws IOException on gitlab api call error
      */
     public List<GitlabTag> getTags(Serializable projectId) throws IOException {
-      String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabTag.URL;
+      String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabTag.URL + PARAM_MAX_ITEMS_PER_PAGE;
       return retrieve().getAll(tailUrl, GitlabTag[].class);
     }
 
@@ -2343,7 +2343,7 @@ public class GitlabAPI {
      * @throws IOException on gitlab api call error
      */
     public List<GitlabTag> getTags(GitlabProject project) throws IOException {
-      String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabTag.URL;
+      String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabTag.URL + PARAM_MAX_ITEMS_PER_PAGE;
       return retrieve().getAll(tailUrl, GitlabTag[].class);
     }
 

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1446,8 +1446,7 @@ public class GitlabAPI {
                 .appendIf("recursive", recursive);
 
         String tailUrl = GitlabProject.URL + "/" + project.getId() + "/repository" + GitlabRepositoryTree.URL + query.toString();
-        GitlabRepositoryTree[] tree = retrieve().to(tailUrl, GitlabRepositoryTree[].class);
-        return Arrays.asList(tree);
+        return retrieve().getAll(tailUrl, GitlabRepositoryTree[].class);
 	}
 
     public GitlabRepositoryFile getRepositoryFile(GitlabProject project, String path, String ref) throws IOException {
@@ -1565,14 +1564,12 @@ public class GitlabAPI {
 
     public List<GitlabBranch> getBranches(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabBranch.URL;
-        GitlabBranch[] branches = retrieve().to(tailUrl, GitlabBranch[].class);
-        return Arrays.asList(branches);
+        return retrieve().getAll(tailUrl, GitlabBranch[].class);
     }
 
     public List<GitlabBranch> getBranches(GitlabProject project) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabBranch.URL;
-        GitlabBranch[] branches = retrieve().to(tailUrl, GitlabBranch[].class);
-        return Arrays.asList(branches);
+        return retrieve().getAll(tailUrl, GitlabBranch[].class);
     }
 
     /**
@@ -2335,8 +2332,7 @@ public class GitlabAPI {
      */
     public List<GitlabTag> getTags(Serializable projectId) throws IOException {
       String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabTag.URL;
-      GitlabTag[] tags = retrieve().to(tailUrl, GitlabTag[].class);
-      return Arrays.asList(tags);
+      return retrieve().getAll(tailUrl, GitlabTag[].class);
     }
 
     /**
@@ -2348,8 +2344,7 @@ public class GitlabAPI {
      */
     public List<GitlabTag> getTags(GitlabProject project) throws IOException {
       String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabTag.URL;
-      GitlabTag[] tags = retrieve().to(tailUrl, GitlabTag[].class);
-      return Arrays.asList(tags);
+      return retrieve().getAll(tailUrl, GitlabTag[].class);
     }
 
     /**


### PR DESCRIPTION
It looks like the v4 API started to paginate endpoints that return arrays/lists of items. I found `getRepositoryTree()`, `getBranches()`, and `getTags()` needed updating for sure. I'm not sure about others, I just confirmed these three.