### PR TITLE
Milestones API: Add start_date field

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1930,6 +1930,7 @@ public class GitlabAPI {
      * @param title The title of the milestone.
      * @param description The description of the milestone. (Optional)
      * @param dueDate The date the milestone is due. (Optional)
+     * @param startDate The start date of the milestone. (Optional)
      * @return The newly created, de-serialized milestone.
      * @throws IOException
      */
@@ -1937,16 +1938,19 @@ public class GitlabAPI {
             Serializable projectId,
             String title,
             String description,
-            Date dueDate) throws IOException {
+            Date dueDate,
+            Date startDate) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + projectId + GitlabMilestone.URL;
         GitlabHTTPRequestor requestor = dispatch().with("title", title);
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
         if (description != null) {
             requestor = requestor.with("description", description);
         }
         if (dueDate != null) {
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-            String formatted = formatter.format(dueDate);
-            requestor = requestor.with("due_date", formatted);
+            requestor = requestor.with("due_date", formatter.format(dueDate));
+        }
+        if (startDate != null) {
+            requestor = requestor.with("start_date", formatter.format(startDate));
         }
         return requestor.to(tailUrl, GitlabMilestone.class);
     }
@@ -1964,7 +1968,8 @@ public class GitlabAPI {
         String title = milestone.getTitle();
         String description = milestone.getDescription();
         Date dateDue = milestone.getDueDate();
-        return createMilestone(projectId, title, description, dateDue);
+        Date dateStart = milestone.getStartDate();
+        return createMilestone(projectId, title, description, dateDue, dateStart);
     }
 
     /**
@@ -1974,6 +1979,7 @@ public class GitlabAPI {
      * @param title The title of the milestone. (Optional)
      * @param description The description of the milestone. (Optional)
      * @param dueDate The date the milestone is due. (Optional)
+     * @param startDate The start date of the milestone. (Optional)
      * @param stateEvent A value used to update the state of the milestone.
      *                   (Optional) (activate | close)
      * @return The updated, de-serialized milestone.
@@ -1985,12 +1991,14 @@ public class GitlabAPI {
             String title,
             String description,
             Date dueDate,
+            Date startDate,
             String stateEvent) throws IOException {
         String tailUrl = GitlabProject.URL + "/" +
                 projectId +
                 GitlabMilestone.URL + "/" +
                 milestoneId;
         GitlabHTTPRequestor requestor = retrieve().method("PUT");
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
         if (title != null) {
             requestor.with("title", title);
         }
@@ -1998,9 +2006,10 @@ public class GitlabAPI {
             requestor = requestor.with("description", description);
         }
         if (dueDate != null) {
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-            String formatted = formatter.format(dueDate);
-            requestor = requestor.with("due_date", formatted);
+            requestor = requestor.with("due_date", formatter.format(dueDate));
+        }
+        if (startDate != null) {
+            requestor = requestor.with("start_date", formatter.format(startDate));
         }
         if (stateEvent != null) {
             requestor.with("state_event", stateEvent);
@@ -2026,6 +2035,7 @@ public class GitlabAPI {
                 edited.getTitle(),
                 edited.getDescription(),
                 edited.getDueDate(),
+                edited.getStartDate(),
                 stateEvent);
     }
 

--- a/src/main/java/org/gitlab/api/models/GitlabMilestone.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMilestone.java
@@ -22,6 +22,9 @@ public class GitlabMilestone {
     @JsonProperty("due_date")
     private Date dueDate;
 
+    @JsonProperty("start_date")
+    private Date startDate;
+
     private String state;
 
     @JsonProperty("updated_date")
@@ -76,6 +79,14 @@ public class GitlabMilestone {
 
     public void setDueDate(Date dueDate) {
         this.dueDate = dueDate;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
     }
 
     public String getState() {


### PR DESCRIPTION
PR for issue #226 


P.S.: Should the order of `dueDate` and `startDate` input arguments for `createMilestone` and `updateMilestone` be reversed or the current order is fine?
