### PR TITLE
Fix for Setting a new Group's Visibility

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -364,7 +364,7 @@ public class GitlabAPI {
      * @throws IOException
      */
     public GitlabGroup getGroup(String path) throws IOException {
-        String tailUrl = GitlabGroup.URL + "/" + path;
+        String tailUrl = GitlabGroup.URL + "/" + URLEncoder.encode(path, "UTF-8");
         return retrieve().to(tailUrl, GitlabGroup.class);
     }
 

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -2,6 +2,7 @@ package org.gitlab.api;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.gitlab.api.http.GitlabHTTPRequestor;
 import org.gitlab.api.http.Query;
 import org.gitlab.api.models.*;
@@ -488,27 +489,16 @@ public class GitlabAPI {
     /**
      * Creates a Group
      *
-     * @param request  The project-creation request
-     * @param sudoUser The user to create the group on behalf of
+     * @param request  An object that represents the parameters for the request.
+     * @param sudoUser The user for whom we're creating the group
      *
      * @return The GitLab Group
      * @throws IOException on gitlab api call error
      */
-    public GitlabGroup createGroup(CreateGroupRequest request, GitlabUser sudoUser) throws IOException {
-
-        Query query = new Query()
-                .append("name", request.getName())
-                .append("path", request.getPath())
-                .appendIf("ldap_cn", request.getLdapCn())
-                .appendIf("description", request.getDescription())
-                .appendIf("membershipLock", request.getMembershipLock())
-                .appendIf("share_with_group_lock", request.getShareWithGroupLock())
-                .appendIf("visibility", request.getVisibility())
-                .appendIf("lfs_enabled", request.getLfsEnabled())
-                .appendIf("request_access_enabled", request.getRequestAccessEnabled())
-                .appendIf("parent_id", request.getParentId())
-                .appendIf(PARAM_SUDO, sudoUser != null ? sudoUser.getId() : null);
-
+    public GitlabGroup createGroup(CreateGroupRequest request, GitlabUser sudoUser) throws IOException {      
+        Query query = request.toQuery();
+        query.appendIf(PARAM_SUDO, sudoUser != null ? sudoUser.getId() : null);
+        
         String tailUrl = GitlabGroup.URL + query.toString();
 
         return dispatch().to(tailUrl, GitlabGroup.class);

--- a/src/main/java/org/gitlab/api/models/CreateGroupRequest.java
+++ b/src/main/java/org/gitlab/api/models/CreateGroupRequest.java
@@ -1,15 +1,21 @@
 package org.gitlab.api.models;
 
+import java.io.UnsupportedEncodingException;
+import org.gitlab.api.http.Query;
 
+/**
+ * The model for custom group-creation requests.
+ *
+ */
 public class CreateGroupRequest {
 
     public CreateGroupRequest(String name) {
-	this(name, name);
+      this(name, name);
     }
 
     public CreateGroupRequest(String name, String path) {
-	this.name = name;
-	this.path = path;
+      this.name = name;
+      this.path = path;
     }
 
     private String name;
@@ -18,10 +24,29 @@ public class CreateGroupRequest {
     private String description;
     private Boolean membershipLock;
     private Boolean shareWithGroupLock;
-    private Boolean visibility;
+    private GitlabVisibility visibility;
     private Boolean lfsEnabled;
     private Boolean requestAccessEnabled;
     private Integer parentId;
+    
+    /**
+     * Generates query representing this request's properties.
+     * @return {@link Query}
+     * @throws UnsupportedEncodingException 
+     */
+    public Query toQuery() throws UnsupportedEncodingException{
+      return new Query()
+          .append("name", name)
+          .append("path", path)
+          .appendIf("ldap_cn", ldapCn)
+          .appendIf("description", description)
+          .appendIf("membershipLock", membershipLock)
+          .appendIf("share_with_group_lock", shareWithGroupLock)
+          .appendIf("visibility", visibility != null ? visibility.toString() : null)
+          .appendIf("lfs_enabled", lfsEnabled)
+          .appendIf("request_access_enabled", requestAccessEnabled)
+          .appendIf("parent_id", parentId);
+    }
 
     public String getName() {
         return name;
@@ -76,11 +101,11 @@ public class CreateGroupRequest {
         return this;
     }
 
-    public Boolean getVisibility() {
+    public GitlabVisibility getVisibility() {
         return visibility;
     }
 
-    public CreateGroupRequest setVisibility(Boolean visibility) {
+    public CreateGroupRequest setVisibility(GitlabVisibility visibility) {
         this.visibility = visibility;
         return this;
     }

--- a/src/main/java/org/gitlab/api/models/GitlabVisibility.java
+++ b/src/main/java/org/gitlab/api/models/GitlabVisibility.java
@@ -1,0 +1,20 @@
+package org.gitlab.api.models;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum for the privacy settings supported by GitLab API v4.
+ */
+public enum GitlabVisibility {
+  PRIVATE, INTERNAL, PUBLIC;
+  
+  /**
+   * Returns lower-case of {@link #name()}. Lower-case is required for requests
+   * that accept a visiblity parameter.
+   */
+  @Override
+  @JsonValue
+  public String toString() {
+    return name().toLowerCase();
+  }
+}


### PR DESCRIPTION
Fixes for issues I had with createGroup.
**getGroup(String)** updated to support seeking subgroups, and **createGroup(createGroupRequest, GitlabUser)** properly allows group visibility to be set.