### PR TITLE
Remove conditional processing for commits

### DIFF
--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -279,16 +279,9 @@ public class GitlabHTTPRequestor {
                     Integer page = Integer.parseInt(matcher.group(2)) + 1;
                     this.url = new URL(matcher.replaceAll(matcher.group(1) + "page=" + page));
                 } else {
-                    if (GitlabCommit[].class == type) {
-                        // there is a bug in the Gitlab CE API
-                        // (https://gitlab.com/gitlab-org/gitlab-ce/issues/759)
-                        // that starts pagination with page=0 for commits
-                        this.url = new URL(url + (url.indexOf('?') > 0 ? '&' : '?') + "page=1");
-                    } else {
-                        // Since the page query was not present, its safe to assume that we just
-                        // currently used the first page, so we can default to page 2
-                        this.url = new URL(url + (url.indexOf('?') > 0 ? '&' : '?') + "&page=2");
-                    }
+                    // Since the page query was not present, its safe to assume that we just
+                    // currently used the first page, so we can default to page 2
+                    this.url = new URL(url + (url.indexOf('?') > 0 ? '&' : '?') + "&page=2");
                 }
             }
         };


### PR DESCRIPTION
https://gitlab.com/gitlab-org/gitlab-ce/issues/759 is closed

gitlab repo id = 13083

https://gitlab.com/api/v4/projects/13083/repository/commits?page=1 
\=\=
https://gitlab.com/api/v4/projects/13083/repository/commits

```bash
diff <(curl -s https://gitlab.com/api/v4/projects/13083/repository/commits) <(curl -s 'https://gitlab.com/api/v4/projects/13083/repository/commits?page=1' )
```

close #237