### PR TITLE
Retrieve group milestones

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1919,8 +1919,17 @@ public class GitlabAPI {
         return getProjectMilestones(String.valueOf(project.getId()));
     }
 
+    public List<GitlabMilestone> getMilestones(GitlabGroup group) throws IOException {
+        return getGroupMilestones(String.valueOf(group.getId()));
+    }
+
     public List<GitlabMilestone> getProjectMilestones(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMilestone.URL;
+        return Arrays.asList(retrieve().to(tailUrl, GitlabMilestone[].class));
+    }
+
+    public List<GitlabMilestone> getGroupMilestones(Serializable groupId) throws IOException {
+        String tailUrl = GitlabGroup.URL + "/" + sanitizeGroupId(groupId) + GitlabMilestone.URL;
         return Arrays.asList(retrieve().to(tailUrl, GitlabMilestone[].class));
     }
 
@@ -2260,12 +2269,20 @@ public class GitlabAPI {
     }
 
     private String sanitizeProjectId(Serializable projectId) {
-        if (!(projectId instanceof String) && !(projectId instanceof Number)) {
-            throw new IllegalArgumentException("projectId needs to be of type String or Number");
+        return sanitizeId(projectId, "projectId");
+    }
+
+    private String sanitizeGroupId(Serializable groupId) {
+        return sanitizeId(groupId, "groupId");
+    }
+
+    private String sanitizeId(Serializable id, String parameterName) {
+        if (!(id instanceof String) && !(id instanceof Number)) {
+            throw new IllegalArgumentException(parameterName + " needs to be of type String or Number");
         }
 
         try {
-            return URLEncoder.encode(String.valueOf(projectId), "UTF-8");
+            return URLEncoder.encode(String.valueOf(id), "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException((e));
         }

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1711,6 +1711,13 @@ public class GitlabAPI {
         return retrieve().getAll(tailUrl, GitlabIssue[].class);
     }
 
+    public List<GitlabIssue> getIssues(GitlabGroup group, GitlabMilestone milestone) throws IOException {
+        String tailUrl = GitlabGroup.URL + "/" + sanitizeGroupId(group.getId())
+                + GitlabMilestone.URL + "/" + sanitizeMilestoneId(milestone.getId())
+                + GitlabIssue.URL + PARAM_MAX_ITEMS_PER_PAGE;
+        return retrieve().getAll(tailUrl, GitlabIssue[].class);
+    }
+
     public GitlabIssue getIssue(Serializable projectId, Integer issueId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabIssue.URL + "/" + issueId;
         return retrieve().to(tailUrl, GitlabIssue.class);
@@ -2274,6 +2281,10 @@ public class GitlabAPI {
 
     private String sanitizeGroupId(Serializable groupId) {
         return sanitizeId(groupId, "groupId");
+    }
+
+    private String sanitizeMilestoneId(Serializable milestoneId) {
+        return sanitizeId(milestoneId, "milestoneId");
     }
 
     private String sanitizeId(Serializable id, String parameterName) {

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1707,7 +1707,7 @@ public class GitlabAPI {
     }
 
     public List<GitlabIssue> getIssues(GitlabProject project) throws IOException {
-        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabIssue.URL + PARAM_MAX_ITEMS_PER_PAGE;
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(project.getId()) + GitlabIssue.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabIssue[].class);
     }
 

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1711,6 +1711,13 @@ public class GitlabAPI {
         return retrieve().getAll(tailUrl, GitlabIssue[].class);
     }
 
+    public List<GitlabIssue> getIssues(GitlabProject project, GitlabMilestone milestone) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(project.getId())
+                + GitlabMilestone.URL + "/" + sanitizeMilestoneId(milestone.getId())
+                + GitlabIssue.URL + PARAM_MAX_ITEMS_PER_PAGE;
+        return retrieve().getAll(tailUrl, GitlabIssue[].class);
+    }
+
     public List<GitlabIssue> getIssues(GitlabGroup group, GitlabMilestone milestone) throws IOException {
         String tailUrl = GitlabGroup.URL + "/" + sanitizeGroupId(group.getId())
                 + GitlabMilestone.URL + "/" + sanitizeMilestoneId(milestone.getId())

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -30,7 +30,7 @@ public class GitlabAPI {
     private static final String API_NAMESPACE = "/api/v4";
     private static final String PARAM_SUDO = "sudo";
     private static final String PARAM_MAX_ITEMS_PER_PAGE = new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).toString();
-    
+
     private final String hostUrl;
 
     private final String apiToken;
@@ -673,7 +673,7 @@ public class GitlabAPI {
 
     /**
      * Uploads a file to a project
-     * 
+     *
      * @param project
      * @param file
      * @return
@@ -683,7 +683,7 @@ public class GitlabAPI {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(project.getId()) + GitlabUpload.URL;
         return dispatch().withAttachment("file", file).to(tailUrl, GitlabUpload.class);
     }
-    
+
     /**
      *
      * Gets a list of a project's jobs in Gitlab
@@ -983,7 +983,7 @@ public class GitlabAPI {
     public List<GitlabMergeRequest> getOpenMergeRequests(Serializable projectId) throws IOException {
         return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_OPENED);
     }
-    
+
     public List<GitlabMergeRequest> getOpenMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
         return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_OPENED, pagination);
     }
@@ -991,15 +991,15 @@ public class GitlabAPI {
     public List<GitlabMergeRequest> getOpenMergeRequests(GitlabProject project) throws IOException {
         return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_OPENED);
     }
-    
+
     public List<GitlabMergeRequest> getOpenMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
         return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_OPENED, pagination);
     }
-    
+
     public List<GitlabMergeRequest> getMergedMergeRequests(Serializable projectId) throws IOException {
         return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_MERGED);
     }
-    
+
     public List<GitlabMergeRequest> getMergedMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
         return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_MERGED, pagination);
     }
@@ -1007,15 +1007,15 @@ public class GitlabAPI {
     public List<GitlabMergeRequest> getMergedMergeRequests(GitlabProject project) throws IOException {
         return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_MERGED);
     }
-    
+
     public List<GitlabMergeRequest> getMergedMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
         return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_MERGED, pagination);
     }
-    
+
     public List<GitlabMergeRequest> getClosedMergeRequests(Serializable projectId) throws IOException {
         return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_CLOSED);
     }
-    
+
     public List<GitlabMergeRequest> getClosedMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
         return getMergeRequestsWithStatus(projectId, GitlabMergeRequest.STATUS_CLOSED, pagination);
     }
@@ -1023,7 +1023,7 @@ public class GitlabAPI {
     public List<GitlabMergeRequest> getClosedMergeRequests(GitlabProject project) throws IOException {
         return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_CLOSED);
     }
-    
+
     public List<GitlabMergeRequest> getClosedMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
         return getMergeRequestsWithStatus(project, GitlabMergeRequest.STATUS_CLOSED, pagination);
     }
@@ -1031,30 +1031,30 @@ public class GitlabAPI {
     public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String status) throws IOException {
         return getMergeRequestsWithStatus(projectId, status, new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE));
     }
-    
+
     public List<GitlabMergeRequest> getMergeRequestsWithStatus(Serializable projectId, String state, Pagination pagination) throws IOException {
         Query query = pagination.asQuery();
         query.append("state", state);
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + query;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
-    
+
     public List<GitlabMergeRequest> getMergeRequestsWithStatus(GitlabProject project, String status) throws IOException {
         return getMergeRequestsWithStatus(project, status, new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE));
     }
-    
+
     public List<GitlabMergeRequest> getMergeRequestsWithStatus(GitlabProject project, String state, Pagination pagination) throws IOException {
         Query query = pagination.asQuery();
         query.append("state", state);
         String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + query;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
-    
+
     public List<GitlabMergeRequest> getMergeRequests(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
-    
+
     public List<GitlabMergeRequest> getMergeRequests(Serializable projectId, Pagination pagination) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + pagination.toString();
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
@@ -1064,7 +1064,7 @@ public class GitlabAPI {
         String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + PARAM_MAX_ITEMS_PER_PAGE;
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
     }
-    
+
     public List<GitlabMergeRequest> getMergeRequests(GitlabProject project, Pagination pagination) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabMergeRequest.URL + pagination.toString();
         return retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
@@ -1077,7 +1077,7 @@ public class GitlabAPI {
 
     /**
      * Cherry picks a commit.
-     * 
+     *
      * @param projectId         The id of the project
      * @param sha               The sha of the commit
      * @param targetBranchName  The branch on which the commit must be cherry-picked
@@ -1088,12 +1088,12 @@ public class GitlabAPI {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/repository/commits/" + sha + "/cherry_pick";
         return retrieve().with("branch", targetBranchName).to(tailUrl, GitlabCommit.class);
     }
-    
+
     public GitlabCommit cherryPick(GitlabProject project, String sha, String targetBranchName) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + project.getId() + "/repository/commits/" + sha + "/cherry_pick";
         return dispatch().with("branch", targetBranchName).to(tailUrl, GitlabCommit.class);
     }
-    
+
     /**
      * Return Merge Request.
      *
@@ -2730,7 +2730,7 @@ public class GitlabAPI {
             return retrieve().getAll(GitlabProject.URL + "/" + project.getId() + GitlabTrigger.URL + PARAM_MAX_ITEMS_PER_PAGE, GitlabTrigger[].class);
         }
     }
-    
+
     /**
      * Gets email-on-push service setup for a projectId.
      * @param projectId The ID of the project containing the variable.
@@ -2740,12 +2740,12 @@ public class GitlabAPI {
         String tailUrl = GitlabProject.URL + "/" + projectId + GitlabServiceEmailOnPush.URL;
         return retrieve().to(tailUrl, GitlabServiceEmailOnPush.class);
     }
-    
+
     /**
      * Update recipients for email-on-push service for a projectId.
      * @param projectId The ID of the project containing the variable.
      * @param emailAddress The emailaddress of the recipent who is going to receive push notification.
-     * @return 
+     * @return
      * @throws IOException
      */
     public boolean updateEmailsOnPush(Integer projectId, String emailAddress) throws IOException {
@@ -2762,7 +2762,7 @@ public class GitlabAPI {
         }
         else
         	appendedRecipients = emailAddress;
-  	    
+
         Query query = new Query()
         .appendIf("active", true)
         .appendIf("recipients", appendedRecipients);
@@ -2770,11 +2770,11 @@ public class GitlabAPI {
         tailUrl = GitlabProject.URL + "/" + projectId + GitlabServiceEmailOnPush.URL + query.toString();
         return retrieve().method("PUT").to(tailUrl, Boolean.class);
     }
-    
+
     /**
      * Get JIRA service settings for a project.
      * https://docs.gitlab.com/ce/api/services.html#get-jira-service-settings
-     * 
+     *
      * @param projectId The ID of the project containing the variable.
      * @return
      * @throws IOException
@@ -2783,11 +2783,11 @@ public class GitlabAPI {
     	String tailUrl = GitlabProject.URL+ "/" + projectId + GitlabServiceJira.URL;
     	return retrieve().to(tailUrl, GitlabServiceJira.class);
     }
-    
+
     /**
      * Remove all previously JIRA settings from a project.
      * https://docs.gitlab.com/ce/api/services.html#delete-jira-service
-     * 
+     *
      * @param projectId The ID of the project containing the variable.
      * @return
      * @throws IOException
@@ -2796,40 +2796,40 @@ public class GitlabAPI {
     	String tailUrl = GitlabProject.URL+ "/" + projectId + GitlabServiceJira.URL;
     	return retrieve().method("DELETE").to(tailUrl, Boolean.class);
     }
-    
+
     /**
      * Set JIRA service for a project.
      * https://docs.gitlab.com/ce/api/services.html#create-edit-jira-service
-     * 
+     *
      * @param projectId The ID of the project containing the variable.
      * @param jiraPropties
      * @return
      * @throws IOException
      */
     public boolean createOrEditJiraService(Integer projectId, GitlabJiraProperties jiraPropties) throws IOException{
-    	
+
     	Query query = new Query()
     			.appendIf("url", jiraPropties.getUrl())
     			.appendIf("project_key", jiraPropties.getProjectKey());
-    	
+
     	if(!jiraPropties.getUsername().isEmpty()){
     		query.appendIf("username", jiraPropties.getUsername());
     	}
-    	
+
     	if(!jiraPropties.getPassword().isEmpty()){
     		query.appendIf("password", jiraPropties.getPassword());
     	}
-    	
+
     	if(jiraPropties.getIssueTransitionId() != null){
     		query.appendIf("jira_issue_transition_id", jiraPropties.getIssueTransitionId());
     	}
-    			
-    	
+
+
     	String tailUrl = GitlabProject.URL+ "/" + projectId + GitlabServiceJira.URL+ query.toString();
     	return retrieve().method("PUT").to(tailUrl, Boolean.class);
-    	
+
     }
-    
+
     /**
     *
     * Get a list of projects accessible by the authenticated user by search.

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1916,10 +1916,10 @@ public class GitlabAPI {
     }
 
     public List<GitlabMilestone> getMilestones(GitlabProject project) throws IOException {
-        return getMilestones(String.valueOf(project.getId()));
+        return getProjectMilestones(String.valueOf(project.getId()));
     }
 
-    public List<GitlabMilestone> getMilestones(Serializable projectId) throws IOException {
+    public List<GitlabMilestone> getProjectMilestones(Serializable projectId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMilestone.URL;
         return Arrays.asList(retrieve().to(tailUrl, GitlabMilestone[].class));
     }

--- a/src/main/java/org/gitlab/api/models/GitlabMilestone.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMilestone.java
@@ -15,6 +15,9 @@ public class GitlabMilestone {
     @JsonProperty("project_id")
     private int projectId;
 
+    @JsonProperty("group_id")
+    private int groupId;
+
     private String title;
 
     private String description;
@@ -52,6 +55,14 @@ public class GitlabMilestone {
 
     public void setProjectId(int projectId) {
         this.projectId = projectId;
+    }
+
+    public int getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(int groupId) {
+        this.groupId = groupId;
     }
 
     public String getTitle() {


### PR DESCRIPTION
Minus some trailing whitespace removed, this PR adds methods to the `GitlabAPI` class to:
* retrieve group milestones
* retrieve group milestone issues
* retrieve project milestone issues

API Reference - https://docs.gitlab.com/ee/api/group_milestones.html