### PR TITLE
Add method and respective model to retrieve issue time stats

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1716,6 +1716,11 @@ public class GitlabAPI {
         return retrieve().to(tailUrl, GitlabIssue.class);
     }
 
+    public GitlabIssueTimeStats getIssueTimeStats(Serializable projectId, Integer issueId) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabIssue.URL + "/" + issueId + GitlabIssueTimeStats.URL;
+        return retrieve().to(tailUrl, GitlabIssueTimeStats.class);
+    }
+
     public GitlabIssue createIssue(int projectId, int assigneeId, Integer milestoneId, String labels,
                                    String description, String title) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + projectId + GitlabIssue.URL;

--- a/src/main/java/org/gitlab/api/models/GitlabIssueTimeStats.java
+++ b/src/main/java/org/gitlab/api/models/GitlabIssueTimeStats.java
@@ -1,0 +1,40 @@
+package org.gitlab.api.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitlabIssueTimeStats {
+
+    public static final String URL = "/time_stats";
+
+    @JsonProperty("time_estimate")
+    private long timeEstimate = 0;
+
+    @JsonProperty("total_time_spent")
+    private long totalTimeSpent = 0;
+
+    @JsonProperty("human_time_estimate")
+    private String humanTimeEstimate;
+
+    @JsonProperty("human_total_time_spent")
+    private String humanTotalTimeSpent;
+
+    public static String getURL() {
+        return URL;
+    }
+
+    public long getTimeEstimate() {
+        return timeEstimate;
+    }
+
+    public long getTotalTimeSpent() {
+        return totalTimeSpent;
+    }
+
+    public String getHumanTimeEstimate() {
+        return humanTimeEstimate;
+    }
+
+    public String getHumanTotalTimeSpent() {
+        return humanTotalTimeSpent;
+    }
+}


### PR DESCRIPTION
This PR adds a method to the `GitlabAPI` class to retrieve the time stats from an issue.

API reference - https://docs.gitlab.com/ee/api/issues.html#get-time-tracking-stats