### PR TITLE
Add method to retrieve projects that the user is member of

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -639,7 +639,8 @@ public class GitlabAPI {
      */
     public List<GitlabProject> getOwnedProjects() throws IOException {
         Query query = new Query().append("owner", "true");
-        String tailUrl = GitlabProject.URL + query.toString() + PARAM_MAX_ITEMS_PER_PAGE;
+        query.mergeWith(new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery());
+        String tailUrl = GitlabProject.URL + query.toString();
         return retrieve().getAll(tailUrl, GitlabProject[].class);
     }
 
@@ -652,7 +653,8 @@ public class GitlabAPI {
      */
     public List<GitlabProject> getStarredProjects() throws IOException {
         Query query = new Query().append("starred", "true");
-        String tailUrl = GitlabProject.URL + query.toString() + PARAM_MAX_ITEMS_PER_PAGE;
+        query.mergeWith(new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery());
+        String tailUrl = GitlabProject.URL + query.toString();
         return retrieve().getAll(tailUrl, GitlabProject[].class);
     }
 

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -646,6 +646,20 @@ public class GitlabAPI {
 
     /**
      *
+     * Get a list of projects that the authenticated user is a member of.
+     *
+     * @return A list of gitlab projects
+     * @throws IOException
+     */
+    public List<GitlabProject> getMembershipProjects() throws IOException {
+        Query query = new Query().append("membership", "true");
+        query.mergeWith(new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery());
+        String tailUrl = GitlabProject.URL + query.toString();
+        return retrieve().getAll(tailUrl, GitlabProject[].class);
+    }
+
+    /**
+     *
      * Get a list of projects starred by the authenticated user.
      *
      * @return A list of gitlab projects

--- a/src/test/java/org/gitlab/api/GitlabAPIIT.java
+++ b/src/test/java/org/gitlab/api/GitlabAPIIT.java
@@ -187,6 +187,12 @@ public class GitlabAPIIT {
     }
 
     @Test
+    public void testGetMembershipProjects() throws IOException {
+        final List<GitlabProject> membershipProjects = api.getMembershipProjects();
+        assertEquals(0, membershipProjects.size());
+    }
+
+    @Test
     public void Check_get_owned_projects() throws IOException {
         final List<GitlabProject> ownedProjects = api.getOwnedProjects();
         assertEquals(0, ownedProjects.size());


### PR DESCRIPTION
This PR first fixes two methods to retrieve owned and starred projects, then adds a new method to retrieve projects that the user is member of. It also adds a test for it.

API Reference - https://docs.gitlab.com/ee/api/projects.html#list-projects

The problem with the fixed methods was that two query objects were being used in the generation of the same url, rendering it like this `/projects?owned=true?page=100` (note `?` twice). This was fixed by merging the two query objects before and using the resulting query object in the generation of the url.