### PR TITLE
getMergeRequestApprovals: use projectId not targetProjectId

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1098,7 +1098,7 @@ public class GitlabAPI {
      * EE only.
      */
     public GitlabMergeRequestApprovals getMergeRequestApprovals(GitlabMergeRequest mr) throws IOException {
-        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(mr.getTargetProjectId()) +
+	String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(mr.getProjectId()) +
             GitlabMergeRequest.URL + "/" + mr.getIid() + GitlabMergeRequestApprovals.URL;
         return retrieve().to(tailUrl, GitlabMergeRequestApprovals.class);
     }


### PR DESCRIPTION
Make the getMergeRequestApprovals API consistent with notes api by
looking at the projectId field instead of the targetProjectId field.
For projects which are sourced from upstream, I believe that these
will be the same (from reading the gitlab code -- the API docs are
unclear; see https://gitlab.com/gitlab-org/gitlab-ce/issues/38539 ).