### PR TITLE
Added getProjectJson() methods

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -619,6 +619,22 @@ public class GitlabAPI {
         return retrieve().to(tailUrl, GitlabProject.class);
     }
 
+    /*
+     * use project id to get Project JSON
+     */
+    public String getProjectJson (Serializable projectId) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId);
+        return retrieve().to(tailUrl, String.class);
+    }
+
+    /*
+     * use namespace & project name to get project
+     */
+    public String getProjectJson(String namespace, String projectName) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeGroupId(namespace) + "%2F" + sanitizeProjectId(projectName);
+        return retrieve().to(tailUrl, String.class);
+    }
+
     /**
      *
      * Get a list of projects accessible by the authenticated user.

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -392,11 +392,14 @@ public class GitlabHTTPRequestor {
                 return type.cast(IOUtils.toByteArray(wrapStream(connection, connection.getInputStream())));
             }
             reader = new InputStreamReader(wrapStream(connection, connection.getInputStream()), "UTF-8");
-            String data = IOUtils.toString(reader);
+            String json = IOUtils.toString(reader);
+            if (type != null && type == String.class) {
+                return type.cast(json);
+            }
             if (type != null && type != Void.class) {
-                return GitlabAPI.MAPPER.readValue(data, type);
+                return GitlabAPI.MAPPER.readValue(json, type);
             } else if (instance != null) {
-                return GitlabAPI.MAPPER.readerForUpdating(instance).readValue(data);
+                return GitlabAPI.MAPPER.readerForUpdating(instance).readValue(json);
             } else {
                 return null;
             }

--- a/src/test/java/org/gitlab/api/GitlabJson.java
+++ b/src/test/java/org/gitlab/api/GitlabJson.java
@@ -1,0 +1,44 @@
+package org.gitlab.api;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+import org.gitlab.api.models.GitlabProject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GitlabJson {
+
+    static GitlabAPI api;
+
+    @BeforeClass
+    public static void getApi() {
+        api = APIForIntegrationTestingHolder.INSTANCE.getApi();
+    }
+
+    @Test
+    public void getProjectJson () throws IOException {
+        List<GitlabProject> projects = api.getProjects();
+        int randomProjectNumber = getRandomProject(projects);
+        if (randomProjectNumber != 0) {
+            String p = api.getProjectJson(randomProjectNumber);
+            assertTrue("The JSON is 0 length",p.length() > 0);
+            assertTrue("Project JSON does not contain 'id'.",p.indexOf("id") > 0);
+            assertTrue("Project JSON does not contain 'default_branch'.",p.indexOf("default_branch") > 0);
+        } else {
+            fail("No projects are defined in the gitlab instance, or something failed.");
+        }
+    }
+
+    private int getRandomProject (List<GitlabProject> projects) {
+        if (projects.size() > 0) {
+            Random rand = new Random();
+            return projects.get(rand.nextInt(projects.size())).getId();
+        } else
+            return 0;
+    }
+}

--- a/src/test/java/org/gitlab/api/http/GitlabHTTPRequestorTest.java
+++ b/src/test/java/org/gitlab/api/http/GitlabHTTPRequestorTest.java
@@ -1,10 +1,9 @@
 package org.gitlab.api.http;
 
-import org.gitlab.api.GitlabAPI;
-import org.gitlab.api.TokenType;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.gitlab.api.GitlabAPI;
+import org.junit.Test;
 
 public class GitlabHTTPRequestorTest {
 


### PR DESCRIPTION
This is a small change to allow the API to pull the project JSON directly from gitlab without parsing it.   One small change to the original code is that I renamed 'data' in GitlabHTTPRequestor.java to json not to override the field 'data' defined in the class.