### PR TITLE
Rename file_name to file_path

### DIFF
--- a/src/main/java/org/gitlab/api/models/GitlabSimpleRepositoryFile.java
+++ b/src/main/java/org/gitlab/api/models/GitlabSimpleRepositoryFile.java
@@ -8,18 +8,18 @@ public class GitlabSimpleRepositoryFile {
    "branch_name": "master"
      */
 
-    @JsonProperty("file_name")
-    private String fileName;
+    @JsonProperty("file_path")
+    private String filePath;
 
-    @JsonProperty("branch_name")
+    @JsonProperty("branch")
     private String branchName;
 
-    public String getFileName() {
-        return fileName;
+    public String getFilePath() {
+        return filePath;
     }
 
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
     }
 
     public String getBranchName() {


### PR DESCRIPTION
Hello,

In the new v4 file repository services in GitLab 10.2.3-ee I see that the field file_name is actually called file_path, despite what is in the official GitLab documentation.  For example, /api/v4/projects/:id/repository/files/:file_path actual response looks like:

{
    "file_path": "example.txt",
    "branch": "master"
}

I think that this is also the case in the ce edition, please correct me if I'm wrong.

Thank you for maintaining this project.