### PR TITLE
Controlled Pagination for Gitlab Projects and Runners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
-	tasks.withType(JavaCompile) {
-		options.encoding = 'UTF-8'
-	}
+    tasks.withType(JavaCompile) {
+        options.encoding = "UTF-8"
+    }
 }
 
 plugins {
@@ -14,8 +14,8 @@ plugins {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-group = 'org.gitlab'
-version = '4.0.1-SNAPSHOT'
+group = "org.gitlab"
+version = "4.0.1-SNAPSHOT"
 
 repositories {
     mavenLocal()
@@ -23,31 +23,31 @@ repositories {
 }
 
 dependencies {
-	compile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.5.+')
-	compile(group: 'commons-io', name: 'commons-io', version: '2.4')
-	testCompile(group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3')
-	testCompile(group: 'junit', name: 'junit', version: '4.12')
+    compile(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.5.+")
+    compile(group: "commons-io", name: "commons-io", version: "2.4")
+    testCompile(group: "org.hamcrest", name: "hamcrest-all", version: "1.3")
+    testCompile(group: "junit", name: "junit", version: "4.12")
 }
 
 jar {
-	manifest { attributes 'Gradle-Version': gradle.gradleVersion }
-	from "LICENSE"
-	from "NOTICE"
+    manifest { attributes "Gradle-Version": gradle.gradleVersion }
+    from "LICENSE"
+    from "NOTICE"
 }
 
 install {
-	repositories.mavenInstaller { pom.artifactId = 'java-gitlab-api' }
+    repositories.mavenInstaller { pom.artifactId = "java-gitlab-api" }
 }
 
 task sourcesJar(type: Jar, dependsOn:classes) {
-	classifier = 'sources'
-	from sourceSets.main.allSource
-	from "LICENSE"
-	from "NOTICE"
+    classifier = "sources"
+    from sourceSets.main.allSource
+    from "LICENSE"
+    from "NOTICE"
 }
 
 artifacts { archives sourcesJar }
 
 task wrapper(type: Wrapper) {
-	gradleVersion = '4.4'
+    gradleVersion = "4.6"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 13 23:55:44 CEST 2015
+#Tue Mar 06 18:55:53 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -683,6 +683,39 @@ public class GitlabAPI {
     }
 
     /**
+     * Get a list of projects of size perPage accessible by the authenticated user.
+     *
+     * @param page    page offset.
+     * @param perPage number elements to get after page offset.
+     * @return A list of gitlab projects
+     * @throws IOException on Gitlab API call error
+     */
+    public List<GitlabProject> getProjectsWithPagination(int page, int perPage) throws IOException {
+        Pagination pagination = new Pagination()
+                .withPage(page)
+                .withPerPage(perPage);
+        return getProjectsWithPagination(pagination);
+    }
+
+    /**
+     * Get a list of projects by pagination accessible by the authenticated user.
+     *
+     * @param pagination
+     * @return
+     * @throws IOException
+     */
+    public List<GitlabProject> getProjectsWithPagination(Pagination pagination) throws IOException {
+        StringBuilder tailUrl = new StringBuilder(GitlabProject.URL);
+
+        if (pagination != null) {
+            Query query = pagination.asQuery();
+            tailUrl.append(query.toString());
+        }
+
+        return Arrays.asList(retrieve().method("GET").to(tailUrl.toString(), GitlabProject[].class));
+    }
+
+    /**
      * Get a list of projects owned by the authenticated user.
      *
      * @return A list of gitlab projects
@@ -733,6 +766,44 @@ public class GitlabAPI {
         query.mergeWith(new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery());
         String tailUrl = GitlabProject.URL + query.toString();
         return retrieve().getAll(tailUrl, GitlabProject[].class);
+    }
+
+    /**
+     * Get a list of projects of perPage elements accessible by the authenticated user given page offset
+     *
+     * @param user    Gitlab User to invoke sudo with
+     * @param page    Page offset
+     * @param perPage Number of elements to get after page offset
+     * @return A list of gitlab projects
+     * @throws IOException Gitlab API call error
+     */
+    public List<GitlabProject> getProjectsViaSudoWithPagination(GitlabUser user, int page, int perPage) throws IOException {
+        Pagination pagination = new Pagination()
+                .withPage(page)
+                .withPerPage(perPage);
+        return getProjectsViaSudoWithPagination(user, pagination);
+    }
+
+    /**
+     * Get a list of projects of with Pagination.
+     *
+     * @param user       Gitlab User to invoke sudo with
+     * @param pagination
+     * @return A list of gitlab projects
+     * @throws IOException Gitlab API call error
+     */
+    public List<GitlabProject> getProjectsViaSudoWithPagination(GitlabUser user, Pagination pagination) throws IOException {
+        StringBuilder tailUrl = new StringBuilder(GitlabProject.URL);
+
+        Query query = new Query()
+                .appendIf(PARAM_SUDO, user.getId());
+
+        if (pagination != null) {
+            query.mergeWith(pagination.asQuery());
+        }
+
+        tailUrl.append(query.toString());
+        return Arrays.asList(retrieve().method("GET").to(tailUrl.toString(), GitlabProject[].class));
     }
 
     /**
@@ -1330,12 +1401,12 @@ public class GitlabAPI {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + "/" + mergeRequestId + "/changes";
         return retrieve().to(tailUrl, GitlabMergeRequest.class);
     }
-    
+
     public GitlabMergeRequest getMergeRequest(Serializable projectId, Integer mergeRequestId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + "/" + mergeRequestId;
         return retrieve().to(tailUrl, GitlabMergeRequest.class);
     }
-    
+
     public GitlabMergeRequest getMergeRequest(GitlabProject project, Integer mergeRequestId) throws IOException {
         return getMergeRequest(project.getId(), mergeRequestId);
     }
@@ -1406,7 +1477,7 @@ public class GitlabAPI {
     public GitlabMergeRequest acceptMergeRequest(GitlabProject project, Integer mergeRequestId, String mergeCommitMessage) throws IOException {
         return acceptMergeRequest(project.getId(), mergeRequestId, mergeCommitMessage);
     }
-    
+
     public GitlabMergeRequest acceptMergeRequest(Serializable projectId, Integer mergeRequestId, String mergeCommitMessage) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabMergeRequest.URL + "/" + mergeRequestId + "/merge";
         GitlabHTTPRequestor requestor = retrieve().method("PUT");
@@ -1574,7 +1645,7 @@ public class GitlabAPI {
     public List<GitlabCommitStatus> getCommitStatuses(GitlabProject project, String commitHash) throws IOException {
         return getCommitStatuses(project.getId(), commitHash, new Pagination());
     }
-    
+
     public List<GitlabCommitStatus> getCommitStatuses(Serializable projectId, String commitHash) throws IOException {
         return getCommitStatuses(projectId, commitHash, new Pagination());
     }
@@ -1583,7 +1654,7 @@ public class GitlabAPI {
                                                       Pagination pagination) throws IOException {
         return getCommitStatuses(project.getId(), commitHash, pagination);
     }
-    
+
     public List<GitlabCommitStatus> getCommitStatuses(Serializable projectId, String commitHash,
                                                       Pagination pagination) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + "/repository" + GitlabCommit.URL + "/" +
@@ -1598,7 +1669,7 @@ public class GitlabAPI {
                                                  String name, String targetUrl, String description) throws IOException {
         return createCommitStatus(project.getId(), commitHash, state, ref, name, targetUrl, description);
     }
-    
+
     public GitlabCommitStatus createCommitStatus(Serializable projectId, String commitHash, String state, String ref,
                                                  String name, String targetUrl, String description) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabCommitStatus.URL + "/" + commitHash;
@@ -3245,7 +3316,7 @@ public class GitlabAPI {
      * @throws IOException
      */
     public List<GitlabRunner> getRunners() throws IOException {
-        return getRunners(GitlabRunner.RunnerScope.ALL);
+        return getRunnersWithPagination(GitlabRunner.RunnerScope.ALL, null);
     }
 
     /**
@@ -3256,16 +3327,55 @@ public class GitlabAPI {
      * @throws IOException on Gitlab API call error
      */
     public List<GitlabRunner> getRunners(GitlabRunner.RunnerScope scope) throws IOException {
-        StringBuilder tailUrl = new StringBuilder("runners/all");
+        return getRunnersWithPagination(scope, null);
+    }
+
+    /**
+     * Returns a list of runners with perPage elements on the page number specified.
+     *
+     * @param scope   Can be null. Defines type of Runner to retrieve.
+     * @param page    Page to get perPage number of Runners from.
+     * @param perPage Number of elements to get per page.
+     * @return List of GitlabRunners
+     * @throws IOException on Gitlab API call error
+     */
+    public List<GitlabRunner> getRunnersWithPagination(GitlabRunner.RunnerScope scope, int page, int perPage) throws IOException {
+        Pagination pagination = new Pagination()
+                .withPage(page)
+                .withPerPage(perPage);
+        return getRunnersWithPagination(scope, pagination);
+    }
+
+    /**
+     * Returns a list of runners with perPage elements on the page number specified.
+     *
+     * @param scope      Can be null. Defines type of Runner to retrieve.
+     * @param pagination Can be null. Pagination to query by.
+     * @return List of GitlabRunners
+     * @throws IOException on Gitlab API call error
+     */
+    public List<GitlabRunner> getRunnersWithPagination(GitlabRunner.RunnerScope scope, Pagination pagination) throws IOException {
+        StringBuilder tailUrl = new StringBuilder(GitlabRunner.URL).append("/all");
         Query query = new Query()
                 .appendIf("scope", scope.getScope());
+
+        if (pagination != null) {
+            query.mergeWith(pagination.asQuery());
+        }
+
         tailUrl.append(query.toString());
-        return retrieve().getAll(tailUrl.toString(), GitlabRunner[].class);
+        return Arrays.asList(retrieve().method("GET").to(tailUrl.toString(), GitlabRunner[].class));
     }
 
+    /**
+     * Get details information of the runner with the specified id.
+     *
+     * @param id Runner id.
+     * @return Extensive GitlabRunner Details.
+     * @throws IOException
+     */
     public GitlabRunner getRunnerDetail(int id) throws IOException {
-        String tailUrl = String.format("runners/%d", id);
+        String tailUrl = String.format("%s/%d", GitlabRunner.URL, id);
         return retrieve().to(tailUrl, GitlabRunner.class);
     }
-
 }

--- a/src/main/java/org/gitlab/api/models/GitlabRunner.java
+++ b/src/main/java/org/gitlab/api/models/GitlabRunner.java
@@ -7,6 +7,8 @@ import java.util.Date;
 import java.util.List;
 
 public class GitlabRunner {
+    public static final String URL = "/runners";
+
     public enum RunnerScope {
         SPECIFIC("specific"),
         SHARED("shared"),

--- a/src/main/java/org/gitlab/api/models/GitlabRunner.java
+++ b/src/main/java/org/gitlab/api/models/GitlabRunner.java
@@ -56,7 +56,10 @@ public class GitlabRunner {
     private String architecture;
     @JsonProperty("projects")
     private List<GitlabProject> projects;
-
+    @JsonProperty("online")
+    private Boolean online;
+    @JsonProperty("status")
+    private String status;
 
     public Integer getId() {
         return this.id;
@@ -163,4 +166,19 @@ public class GitlabRunner {
         this.architecture = architecture;
     }
 
+    public Boolean getOnline() {
+        return this.online;
+    }
+
+    public void setOnline(boolean online) {
+        this.online = online;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
 }


### PR DESCRIPTION
# Changes
- Allow for controlled pagination of Projects and Runners API
- Add new Runners API fields `online` and `status`
