### PR TITLE
Added a new method to create a new SSH key

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -334,7 +334,7 @@ public class GitlabAPI {
                 .append("title", title)
                 .append("key", key);
 
-        String tailUrl = GitlabUser.USERS_URL + GitlabSSHKey.KEYS_URL + query.toString();
+        String tailUrl = GitlabUser.USER_URL + GitlabSSHKey.KEYS_URL + query.toString();
 
         return dispatch().to(tailUrl, GitlabSSHKey.class);
     }

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -323,7 +323,6 @@ public class GitlabAPI {
     /**
      * Create a new ssh key for the authenticated user.
      *
-     * @param targetUserId The id of the Gitlab user
      * @param title        The title of the ssh key
      * @param key          The public key
      * @return The new GitlabSSHKey
@@ -335,7 +334,7 @@ public class GitlabAPI {
                 .append("title", title)
                 .append("key", key);
 
-        String tailUrl = GitlabUser.USERS_URL + "/" + GitlabSSHKey.KEYS_URL + query.toString();
+        String tailUrl = GitlabUser.USERS_URL + GitlabSSHKey.KEYS_URL + query.toString();
 
         return dispatch().to(tailUrl, GitlabSSHKey.class);
     }

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -319,6 +319,26 @@ public class GitlabAPI {
 
         return dispatch().to(tailUrl, GitlabSSHKey.class);
     }
+    
+    /**
+     * Create a new ssh key for the authenticated user.
+     *
+     * @param targetUserId The id of the Gitlab user
+     * @param title        The title of the ssh key
+     * @param key          The public key
+     * @return The new GitlabSSHKey
+     * @throws IOException on gitlab api call error
+     */
+    public GitlabSSHKey createSSHKey(String title, String key) throws IOException {
+
+        Query query = new Query()
+                .append("title", title)
+                .append("key", key);
+
+        String tailUrl = GitlabUser.USERS_URL + "/" + GitlabSSHKey.KEYS_URL + query.toString();
+
+        return dispatch().to(tailUrl, GitlabSSHKey.class);
+    }
 
     /**
      * Delete user's ssh key


### PR DESCRIPTION
Added a new method to create a new SSH key for the current user (https://docs.gitlab.com/ce/api/users.html#add-ssh-key) because the other method already available doesn't work if the user is not admin (https://docs.gitlab.com/ce/api/users.html#add-ssh-key-for-user) and wants to add a new SSH key for him.