### PR TITLE
Fix getProjects. Fix for issue #302

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -803,8 +803,10 @@ public class GitlabAPI {
      *
      * @return A list of gitlab projects
      */
-    public List<GitlabProject> getProjects() {
-        String tailUrl = GitlabProject.URL + PARAM_MAX_ITEMS_PER_PAGE;
+    public List<GitlabProject> getProjects() throws IOException {
+        Query query = new Query().append("membership", "true");
+        query.mergeWith(new Pagination().withPerPage(Pagination.MAX_ITEMS_PER_PAGE).asQuery());
+        String tailUrl = GitlabProject.URL + query.toString();
         return retrieve().getAll(tailUrl, GitlabProject[].class);
     }
 


### PR DESCRIPTION
According to [https://docs.gitlab.com/ee/api/v3_to_v4.html#9-0](url):
*GET **/projects** returns all projects visible to current user, even if the user is not a member !9674
**To get projects the user is a member of, use **GET /projects?membership=true**