### PR TITLE
Add api to fetch single tag

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -3320,6 +3320,19 @@ public class GitlabAPI {
     }
 
     /**
+     * Get a single repository tag in a specific project
+     *
+     * @param project (required) The ID or URL-encoded path of the project
+     * @param tagName (required) The name of the tag
+     * @return the found git tag object
+     * @throws IOException on gitlab api call error
+     */
+    public GitlabTag getTag(GitlabProject project, String tagName) throws IOException {
+        String tailUrl = GitlabProject.URL + "/" + project.getId() + GitlabTag.URL + "/" + tagName;
+        return retrieve().to(tailUrl, GitlabTag.class);
+    }
+
+    /**
      * Create tag in specific project
      *
      * @param projectId


### PR DESCRIPTION
This PR add a method to get single tag from gitlab. The corresponding api spec can be found here: https://docs.gitlab.com/ee/api/projects.html#get-single-project