### PR TITLE
adjusting getters return type

### DIFF
--- a/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
@@ -251,7 +251,7 @@ public class GitlabMergeRequest {
         this.labels = labels;
     }
 
-    public int getUpvotes() {
+    public Integer getUpvotes() {
         return upvotes;
     }
 
@@ -259,7 +259,7 @@ public class GitlabMergeRequest {
         this.upvotes = upvotes;
     }
 
-    public int getDownvotes() {
+    public Integer getDownvotes() {
         return downvotes;
     }
 
@@ -352,7 +352,7 @@ public class GitlabMergeRequest {
         return shouldRemoveSourceBranch;
     }
 
-    public boolean isForceRemoveSourceBranch() {
+    public Boolean isForceRemoveSourceBranch() {
         return forceRemoveSourceBranch;
     }
 


### PR DESCRIPTION
Some getters are returning primitive values instead of the declared Object types, causing problems with serialization and npe.