### PR TITLE
Files containing spaces in their path are wrongly encoded (#331)

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -3275,7 +3275,7 @@ public class GitlabAPI {
 
     private String sanitizePath(String branch) {
         try {
-            return URLEncoder.encode(branch, "UTF-8");
+            return URLEncoder.encode(branch, "UTF-8").replaceAll("\\+", "%20");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException((e));
         }


### PR DESCRIPTION
- Encode '+' characters in paths with '%20'