### PR TITLE
update GitlabMergeRequest prop changesCount to string

### DIFF
--- a/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
+++ b/src/main/java/org/gitlab/api/models/GitlabMergeRequest.java
@@ -87,7 +87,7 @@ public class GitlabMergeRequest {
     private Boolean squash;
 
     @JsonProperty("changes_count")
-    private Integer changesCount;
+    private String changesCount;
 
     @JsonProperty("merged_by")
     private GitlabUser mergedBy;
@@ -360,7 +360,7 @@ public class GitlabMergeRequest {
         return squash;
     }
 
-    public Integer getChangesCount() {
+    public String getChangesCount() {
         return changesCount;
     }
 


### PR DESCRIPTION
Fix the type of changesCount in the GitlabMergeRequest Model
GitlabApi official website:
https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
![image](https://user-images.githubusercontent.com/6405415/52838037-2f18fe80-312c-11e9-9c86-4ce04bde6ebd.png)
Sometimes the '+' will appear
![image](https://user-images.githubusercontent.com/6405415/52838133-8fa83b80-312c-11e9-8cf5-145021653a06.png)

I update the type to string
