### PR TITLE
Throw UncheckedIOException instead of generic RuntimeException

### DIFF
--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.net.*;
 import java.util.*;

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -188,7 +188,7 @@ public class GitlabHTTPRequestor {
                 try {
                     url = root.getAPIUrl(tailApiUrl);
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
             }
 
@@ -240,7 +240,7 @@ public class GitlabHTTPRequestor {
                         handleAPIError(e, connection);
                     }
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
             }
 


### PR DESCRIPTION
In issue #337 we discussed rethrowing the IOException from the API border, but since many methods nowadays don't `throws IOException` it would be a huge breaking change.

I therefore decided to only change the exception type from RuntimeException to UncheckedIOException to be able to distinguish between them in API consuming business logic. For consumers already catching RuntimeException to handle the wrapped IOException, nothing will change.