### PR TITLE
Fix commits pagination

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1995,7 +1995,7 @@ public class GitlabAPI {
 
     public List<GitlabCommit> getCommits(Serializable projectId, Pagination pagination,
                                          String branchOrTag) throws IOException {
-        return getCommits(projectId, null, branchOrTag, null);
+        return getCommits(projectId, pagination, branchOrTag, null);
     }
 
     public List<GitlabCommit> getCommits(Serializable projectId, Pagination pagination,


### PR DESCRIPTION
Hi,

In the `GitLabAPI.getCommits(projectId, pagination, branchOrTag), the pagination argument is ignored when invoking the extended `getCommit` method. Since there is no warning about that, not all the commits will come back.

A temporary fix in 4.0.1 is to directly call `getCommits(projectId, pagination, branchOrTag, null)`.

Best regards !
Cédric