### PR TITLE
Proposal, use specialized query objects instead of parameters

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.gitlab.api.http.GitlabHTTPRequestor;
 import org.gitlab.api.http.Query;
 import org.gitlab.api.models.*;
+import org.gitlab.api.query.PaginationQuery;
+import org.gitlab.api.query.ProjectsQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -841,6 +843,16 @@ public class GitlabAPI {
                 .withPage(page)
                 .withPerPage(perPage);
         return getProjectsWithPagination(pagination);
+    }
+
+    /**
+     * Get a list of projects accessible by the authenticated user.
+     *
+     * @return A list of gitlab projects
+     */
+    public List<GitlabProject> getProjects(ProjectsQuery projectsQuery) {
+        String tailUrl = GitlabProject.URL + projectsQuery;
+        return retrieve().getAll(tailUrl, GitlabProject[].class);
     }
 
     /**

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -6,6 +6,7 @@ import org.gitlab.api.http.GitlabHTTPRequestor;
 import org.gitlab.api.http.Query;
 import org.gitlab.api.models.*;
 import org.gitlab.api.query.PaginationQuery;
+import org.gitlab.api.query.PipelinesQuery;
 import org.gitlab.api.query.ProjectsQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1009,6 +1010,47 @@ public class GitlabAPI {
     public GitlabPipeline getProjectPipeline(Integer projectId, Integer pipelineId) throws IOException {
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabPipeline.URL + "/" + sanitizeId(pipelineId, "pipelineId");
         return retrieve().to(tailUrl, GitlabPipeline.class);
+    }
+
+    /**
+     * Get a list of a project's pipelines in Gitlab
+     *
+     * @param project the project
+     * @return A list of project pipelines
+     */
+    public List<GitlabPipeline> getProjectPipelines(GitlabProject project) {
+        return getProjectPipelines(project.getId());
+    }
+
+    /**
+     * Get a list of a project's pipelines in Gitlab
+     *
+     * @param projectId the project id
+     * @return A list of project pipelines
+     */
+    public List<GitlabPipeline> getProjectPipelines(Integer projectId) {
+        return getProjectPipelines(projectId, new PipelinesQuery().withPerPage(PaginationQuery.MAX_ITEMS_PER_PAGE));
+    }
+
+    /**
+     * Get a list of a project's pipelines in Gitlab
+     *
+     * @param project the project
+     * @return A list of project pipelines
+     */
+    public List<GitlabPipeline> getProjectPipelines(GitlabProject project, PipelinesQuery pipelinesQuery) {
+        return getProjectPipelines(project.getId(), pipelinesQuery);
+    }
+
+    /**
+     * Get a list of a project's pipelines in Gitlab
+     *
+     * @param projectId the project id
+     * @return A list of project pipelines
+     */
+    public List<GitlabPipeline> getProjectPipelines(Integer projectId, PipelinesQuery pipelinesQuery) {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabPipeline.URL + pipelinesQuery;
+        return retrieve().getAll(tailUrl, GitlabPipeline[].class);
     }
 
     /**

--- a/src/main/java/org/gitlab/api/Pagination.java
+++ b/src/main/java/org/gitlab/api/Pagination.java
@@ -1,48 +1,44 @@
 package org.gitlab.api;
 
 import org.gitlab.api.http.Query;
+import org.gitlab.api.query.PaginationQuery;
 
-import java.io.UnsupportedEncodingException;
+/**
+ * @deprecated Use {@link PaginationQuery#PARAM_PAGE} instead.
+ */
+@Deprecated
+public class Pagination extends PaginationQuery {
 
-public class Pagination {
-    public static final String PARAM_PAGE = "page";
-    public static final String PARAM_PER_PAGE = "per_page";
-    public static final int MAX_ITEMS_PER_PAGE = 100;
-    private final Query paginationQuery = new Query();
+    /**
+     * @deprecated Use {@link PaginationQuery#PARAM_PAGE} instead.
+     */
+    @Deprecated
+    public static final String PARAM_PAGE = PaginationQuery.PARAM_PAGE;
 
-    public void setPage(int page) {
-        try {
-            paginationQuery.append(PARAM_PAGE, String.valueOf(page));
-        } catch (UnsupportedEncodingException ignored) {
-        }
-    }
+    /**
+      @deprecated Use {@link PaginationQuery#PARAM_PER_PAGE} instead.
+     */
+    @Deprecated
+    public static final String PARAM_PER_PAGE = PaginationQuery.PARAM_PER_PAGE;
 
-    public void setPerPage(int perPage) {
-        if (perPage > MAX_ITEMS_PER_PAGE) {
-            throw new IllegalArgumentException("Max value for perPage is " + MAX_ITEMS_PER_PAGE);
-        }
-        try {
-            paginationQuery.append(PARAM_PER_PAGE, String.valueOf(perPage));
-        } catch (UnsupportedEncodingException ignored) {
-        }
-    }
-    
+    /**
+      @deprecated Use {@link PaginationQuery#MAX_ITEMS_PER_PAGE} instead.
+     */
+    @Deprecated
+    public static final int MAX_ITEMS_PER_PAGE = PaginationQuery.MAX_ITEMS_PER_PAGE;
+
     public Pagination withPage(int page) {
         setPage(page);
         return this;
     }
-    
+
     public Pagination withPerPage(int perPage) {
         setPerPage(perPage);
         return this;
     }
 
     public Query asQuery() {
-        return paginationQuery;
+        return this;
     }
 
-    @Override
-    public String toString() {
-        return paginationQuery.toString();
-    }
 }

--- a/src/main/java/org/gitlab/api/query/PaginationQuery.java
+++ b/src/main/java/org/gitlab/api/query/PaginationQuery.java
@@ -1,0 +1,40 @@
+package org.gitlab.api.query;
+
+import org.gitlab.api.http.Query;
+
+import java.io.UnsupportedEncodingException;
+
+public class PaginationQuery extends Query {
+
+    public static final String PARAM_PAGE = "page";
+    public static final String PARAM_PER_PAGE = "per_page";
+    public static final int MAX_ITEMS_PER_PAGE = 100;
+
+    public void setPage(int page) {
+        try {
+            append(PARAM_PAGE, String.valueOf(page));
+        } catch (UnsupportedEncodingException ignored) {
+        }
+    }
+
+    public void setPerPage(int perPage) {
+        if (perPage > MAX_ITEMS_PER_PAGE) {
+            throw new IllegalArgumentException("Max value for perPage is " + MAX_ITEMS_PER_PAGE);
+        }
+        try {
+            append(PARAM_PER_PAGE, String.valueOf(perPage));
+        } catch (UnsupportedEncodingException ignored) {
+        }
+    }
+
+    public PaginationQuery withPage(int page) {
+        setPage(page);
+        return this;
+    }
+
+    public PaginationQuery withPerPage(int perPage) {
+        setPerPage(perPage);
+        return this;
+    }
+
+}

--- a/src/main/java/org/gitlab/api/query/PipelinesQuery.java
+++ b/src/main/java/org/gitlab/api/query/PipelinesQuery.java
@@ -1,0 +1,100 @@
+package org.gitlab.api.query;
+
+import java.io.UnsupportedEncodingException;
+
+public class PipelinesQuery extends PaginationQuery {
+
+    public void setScope(String scope) throws UnsupportedEncodingException {
+        appendIf("scope", scope);
+    }
+
+    public PipelinesQuery withScope(String scope) throws UnsupportedEncodingException {
+        this.setScope(scope);
+        return this;
+    }
+
+    public void setStatus(String status) throws UnsupportedEncodingException {
+        appendIf("status", status);
+    }
+
+    public PipelinesQuery withStatus(String status) throws UnsupportedEncodingException {
+        this.setStatus(status);
+        return this;
+    }
+
+    public void setRef(String ref) throws UnsupportedEncodingException {
+        appendIf("ref", ref);
+    }
+
+    public PipelinesQuery withRef(String ref) throws UnsupportedEncodingException {
+        this.setRef(ref);
+        return this;
+    }
+
+    public void setSha(String sha) throws UnsupportedEncodingException {
+        appendIf("sha", sha);
+    }
+
+    public PipelinesQuery withSha(String sha) throws UnsupportedEncodingException {
+        this.setSha(sha);
+        return this;
+    }
+
+    public void setYamlErrors(Boolean yamlErrors) throws UnsupportedEncodingException {
+        appendIf("yaml_errors", yamlErrors);
+    }
+
+    public PipelinesQuery withYamlErrors(Boolean yamlErrors) throws UnsupportedEncodingException {
+        this.setYamlErrors(yamlErrors);
+        return this;
+    }
+
+    public void setName(String name) throws UnsupportedEncodingException {
+        appendIf("name", name);
+    }
+
+    public PipelinesQuery withName(String name) throws UnsupportedEncodingException {
+        this.setName(name);
+        return this;
+    }
+
+    public void setUsername(String username) throws UnsupportedEncodingException {
+        appendIf("username", username);
+    }
+
+    public PipelinesQuery withUsername(String username) throws UnsupportedEncodingException {
+        this.setUsername(username);
+        return this;
+    }
+
+    public void setOrderBy(String orderBy) throws UnsupportedEncodingException {
+        appendIf("order_by", orderBy);
+    }
+
+    public PipelinesQuery withOrderBy(String orderBy) throws UnsupportedEncodingException {
+        this.setOrderBy(orderBy);
+        return this;
+    }
+
+    public void setSort(String sort) throws UnsupportedEncodingException {
+        appendIf("sort", sort);
+    }
+
+    public PipelinesQuery withSort(String sort) throws UnsupportedEncodingException {
+        this.setSort(sort);
+        return this;
+    }
+
+    @Override
+    public PipelinesQuery withPage(int page) {
+        super.withPage(page);
+        return this;
+    }
+
+    @Override
+    public PipelinesQuery withPerPage(int perPage) {
+        super.withPerPage(perPage);
+        return this;
+    }
+
+}

--- a/src/main/java/org/gitlab/api/query/ProjectsQuery.java
+++ b/src/main/java/org/gitlab/api/query/ProjectsQuery.java
@@ -1,0 +1,192 @@
+package org.gitlab.api.query;
+
+import org.gitlab.api.models.GitlabAccessLevel;
+
+import java.io.UnsupportedEncodingException;
+
+public class ProjectsQuery extends PaginationQuery {
+
+    public static final String PARAM_ARCHIVED = "archived";
+    public static final String PARAM_VISIBILITY = "visibility";
+    public static final String PARAM_ORDER_BY = "order_by";
+    public static final String PARAM_SORT = "sort";
+    public static final String PARAM_SEARCH = "search";
+    public static final String PARAM_SIMPLE = "simple";
+    public static final String PARAM_OWNED = "owned";
+    public static final String PARAM_MEMBERSHIP = "membership";
+    public static final String PARAM_STARRED = "starred";
+    public static final String PARAM_STATISTICS = "statistics";
+    public static final String PARAM_WITH_CUSTOM_ATTRIBUTES = "with_custom_attributes";
+    public static final String PARAM_WITH_ISSUES_ENABLED = "with_issues_enabled";
+    public static final String PARAM_WITH_MERGE_REQUESTS_ENABLED = "with_merge_requests_enabled";
+    public static final String PARAM_WITH_PROGRAMMING_LANGUAGE = "with_programming_language";
+    public static final String PARAM_WIKI_CHECKSUM_FAILED = "wiki_checksum_failed";
+    public static final String PARAM_REPOSITORY_CHECKSUM_FAILED = "repository_checksum_failed";
+    public static final String PARAM_MIN_ACCESS_LEVEL = "min_access_level";
+
+    public void setArchived(Boolean archived) throws UnsupportedEncodingException {
+        appendIf(PARAM_ARCHIVED, archived);
+    }
+
+    public ProjectsQuery withArchived(Boolean archived) throws UnsupportedEncodingException {
+        setArchived(archived);
+        return this;
+    }
+
+    public void setVisibility(String visibility) throws UnsupportedEncodingException {
+        appendIf(PARAM_VISIBILITY, visibility);
+    }
+
+    public ProjectsQuery withVisibility(String visibility) throws UnsupportedEncodingException {
+        setVisibility(visibility);
+        return this;
+    }
+
+    public void setOrderBy(String orderBy) throws UnsupportedEncodingException {
+        appendIf(PARAM_ORDER_BY, orderBy);
+    }
+
+    public ProjectsQuery withOrderBy(String orderBy) throws UnsupportedEncodingException {
+        setOrderBy(orderBy);
+        return this;
+    }
+
+    public void setSort(String sort) throws UnsupportedEncodingException {
+        appendIf(PARAM_SORT, sort);
+    }
+
+    public ProjectsQuery withSort(String sort) throws UnsupportedEncodingException {
+        setSort(sort);
+        return this;
+    }
+
+    public void setSearch(String search) throws UnsupportedEncodingException {
+        appendIf(PARAM_SEARCH, search);
+    }
+
+    public ProjectsQuery withSearch(String search) throws UnsupportedEncodingException {
+        setSearch(search);
+        return this;
+    }
+
+    public void setSimple(Boolean simple) throws UnsupportedEncodingException {
+        appendIf(PARAM_SIMPLE, simple);
+    }
+
+    public ProjectsQuery withSimple(Boolean simple) throws UnsupportedEncodingException {
+        setSimple(simple);
+        return this;
+    }
+
+    public void setOwned(Boolean owned) throws UnsupportedEncodingException {
+        appendIf(PARAM_OWNED, owned);
+    }
+
+    public ProjectsQuery withOwned(Boolean owned) throws UnsupportedEncodingException {
+        setOwned(owned);
+        return this;
+    }
+
+    public void setMembership(Boolean membership) throws UnsupportedEncodingException {
+        appendIf(PARAM_MEMBERSHIP, membership);
+    }
+
+    public ProjectsQuery withMembership(Boolean membership) throws UnsupportedEncodingException {
+        setMembership(membership);
+        return this;
+    }
+
+    public void setStarred(Boolean starred) throws UnsupportedEncodingException {
+        appendIf(PARAM_STARRED, starred);
+    }
+
+    public ProjectsQuery withStarred(Boolean starred) throws UnsupportedEncodingException {
+        setStarred(starred);
+        return this;
+    }
+
+    public void setStatistics(Boolean statistics) throws UnsupportedEncodingException {
+        appendIf(PARAM_STATISTICS, statistics);
+    }
+
+    public ProjectsQuery withStatistics(Boolean statistics) throws UnsupportedEncodingException {
+        setStatistics(statistics);
+        return this;
+    }
+
+    public void setWithCustomAttributes(Boolean withCustomAttributes) throws UnsupportedEncodingException {
+        appendIf(PARAM_WITH_CUSTOM_ATTRIBUTES, withCustomAttributes);
+    }
+
+    public ProjectsQuery withWithCustomAttributes(Boolean withCustomAttributes) throws UnsupportedEncodingException {
+        setWithCustomAttributes(withCustomAttributes);
+        return this;
+    }
+
+    public void setWithIssuesEnabled(Boolean withIssuesEnabled) throws UnsupportedEncodingException {
+        appendIf(PARAM_WITH_ISSUES_ENABLED, withIssuesEnabled);
+    }
+
+    public ProjectsQuery withWithIssuesEnabled(Boolean withIssuesEnabled) throws UnsupportedEncodingException {
+        setWithIssuesEnabled(withIssuesEnabled);
+        return this;
+    }
+
+    public void setWithMergeRequestsEnabled(Boolean withMergeRequestsEnabled) throws UnsupportedEncodingException {
+        appendIf(PARAM_WITH_MERGE_REQUESTS_ENABLED, withMergeRequestsEnabled);
+    }
+
+    public ProjectsQuery withWithMergeRequestsEnabled(Boolean withMergeRequestsEnabled) throws UnsupportedEncodingException {
+        setWithMergeRequestsEnabled(withMergeRequestsEnabled);
+        return this;
+    }
+
+    public void setWithProgrammingLanguage(String withProgrammingLanguage) throws UnsupportedEncodingException {
+        appendIf(PARAM_WITH_PROGRAMMING_LANGUAGE, withProgrammingLanguage);
+    }
+
+    public ProjectsQuery withWithProgrammingLanguage(String withProgrammingLanguage) throws UnsupportedEncodingException {
+        setWithProgrammingLanguage(withProgrammingLanguage);
+        return this;
+    }
+
+    public void setWikiChecksumFailed(Boolean wikiChecksumFailed) throws UnsupportedEncodingException {
+        appendIf(PARAM_WIKI_CHECKSUM_FAILED, wikiChecksumFailed);
+    }
+
+    public ProjectsQuery withWikiChecksumFailed(Boolean wikiChecksumFailed) throws UnsupportedEncodingException {
+        setWikiChecksumFailed(wikiChecksumFailed);
+        return this;
+    }
+
+    public void setRepositoryChecksumFailed(Boolean repositoryChecksumFailed) throws UnsupportedEncodingException {
+        appendIf(PARAM_REPOSITORY_CHECKSUM_FAILED, repositoryChecksumFailed);
+    }
+
+    public ProjectsQuery withRepositoryChecksumFailed(Boolean repositoryChecksumFailed) throws UnsupportedEncodingException {
+        setRepositoryChecksumFailed(repositoryChecksumFailed);
+        return this;
+    }
+
+    public void setMinAccessLevel(GitlabAccessLevel minAccessLevel) throws UnsupportedEncodingException {
+        appendIf(PARAM_MIN_ACCESS_LEVEL, minAccessLevel);
+    }
+
+    public ProjectsQuery withMinAccessLevel(GitlabAccessLevel minAccessLevel) throws UnsupportedEncodingException {
+        setMinAccessLevel(minAccessLevel);
+        return this;
+    }
+
+    @Override
+    public ProjectsQuery withPage(int page) {
+        super.withPage(page);
+        return this;
+    }
+
+    @Override
+    public ProjectsQuery withPerPage(int perPage) {
+        super.withPerPage(perPage);
+        return this;
+    }
+
+}


### PR DESCRIPTION
The gitlab api provides numerous parameters. Most are currently not offered by java-gitlab-api.

The current design provides API parameters individually as method parameters. This is not very future proof and clumsy.

Instead, one could directly accept a query object. In order to get at least a certain abstraction, one simply derives sub-classes for the respective use cases.
Because I did not "hide" the query (as implemented in the old pagination class), it is also possible to add parameters that may be added to the API in the future. This would basically make the methods forward-compatible.

I made the whole example of the `GitlabAPI#getProjects()` ([GitlabAPI](https://github.com/tristanlins/java-gitlab-api/blob/feature-specialized-queries/src/main/java/org/gitlab/api/GitlabAPI.java#L834-L842), [ProjectsQuery](https://github.com/tristanlins/java-gitlab-api/blob/feature-specialized-queries/src/main/java/org/gitlab/api/query/ProjectsQuery.java)) and the newly added `GitlabAPI#getProjectPipelines()` ([GitlabAPI](https://github.com/tristanlins/java-gitlab-api/blob/feature-specialized-queries/src/main/java/org/gitlab/api/GitlabAPI.java#L977-L1016), [PipelinesQuery](https://github.com/tristanlins/java-gitlab-api/blob/feature-specialized-queries/src/main/java/org/gitlab/api/query/PipelinesQuery.java)).