### PR TITLE
Get commits for merge request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services:
   - docker
 jdk:
-- oraclejdk8
+- openjdk8
 install:
 - ./mvnw -B -q -Pdocker-gitlab dependency:go-offline verify -DskipTests -Ddocker.skip
 script:

--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -2125,13 +2125,9 @@ public class GitlabAPI {
             projectId = mergeRequest.getProjectId();
         }
 
-        Query query = new Query()
-                .append("ref_name", mergeRequest.getSourceBranch());
-
-        query.mergeWith(pagination.asQuery());
-
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) +
-                "/repository" + GitlabCommit.URL + query.toString();
+                GitlabMergeRequest.URL + "/" + mergeRequest.getIid() +
+                GitlabCommit.URL + pagination.toString();
 
         GitlabCommit[] commits = retrieve().to(tailUrl, GitlabCommit[].class);
         return Arrays.asList(commits);

--- a/src/test/java/org/gitlab/api/GitlabAPIUT.java
+++ b/src/test/java/org/gitlab/api/GitlabAPIUT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.NoRouteToHostException;
 import java.net.ServerSocket;
 import java.net.SocketTimeoutException;
 
@@ -23,8 +24,8 @@ public class GitlabAPIUT {
     public void unitTest_20180503175711() {
         GitlabAPI api = GitlabAPI.connect("http://172.16.0.0:80", "test");
         api.setConnectionTimeout(100);
-        Throwable exception = assertThrows(SocketTimeoutException.class, api::getVersion);
-        assertThat(exception.getMessage(), is("connect timed out"));
+        Throwable exception = assertThrows(NoRouteToHostException.class, api::getVersion);
+        assertThat(exception.getMessage(), is("No route to host"));
     }
 
     @Test

--- a/src/test/java/org/gitlab/api/InstantDeserializerTest.java
+++ b/src/test/java/org/gitlab/api/InstantDeserializerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.*;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,7 +25,7 @@ class InstantDeserializerTest {
         assertEquals(Instant.from(
             ZonedDateTime.of(
                 LocalDate.of(2016, 8, 11),
-                LocalTime.of(11, 28, 34, 85),
+                LocalTime.of(11, 28, 34, (int) TimeUnit.MILLISECONDS.toNanos(85)),
                 ZoneOffset.UTC
             )
         ), instant);


### PR DESCRIPTION
 closes #259

Tests passed locally:

```
$ mvn -Pdocker-gitlab clean verify
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.gitlab.api.GitlabUploadIT
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.088 s - in org.gitlab.api.GitlabUploadIT
[INFO] Running org.gitlab.api.GitlabAPIIT
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 s - in org.gitlab.api.GitlabAPIIT
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 2
[INFO] 
[INFO] 
[INFO] --- docker-maven-plugin:0.23.0:stop (default-stop) @ java-gitlab-api ---
[INFO] DOCKER> [gitlab/gitlab-ce:latest] "gitlab": Stop and removed container fc9c6500b22c after 0 ms
[INFO] 
[INFO] --- maven-failsafe-plugin:2.21.0:verify (default-verify) @ java-gitlab-api ---
[INFO] 
[INFO] --- maven-source-plugin:3.0.0:jar-no-fork (attach-sources) @ java-gitlab-api ---
[INFO] Building jar: /home/ronak/github/java-gitlab-api/target/java-gitlab-api-4.1.1-SNAPSHOT-sources.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:01 min
[INFO] Finished at: 2019-10-14T15:46:48-05:00
[INFO] ------------------------------------------------------------------------
```

```
<?xml version="1.0" encoding="UTF-8"?><testrun duration="1428" footerText="Generated by IntelliJ IDEA on 10/14/19, 3:56 PM" name="Tests in 'java-gitlab-api.test'">
    <count name="total" value="35"/>
    <count name="ignored" value="3"/>
    <count name="passed" value="32"/>
    <config configId="GradleRunConfiguration" name="Tests in 'java-gitlab-api.test'">
        <ExternalSystemSettings>
            <option name="executionName"/>
            <option name="externalProjectPath" value="/home/ronak/github/java-gitlab-api"/>
            <option name="externalSystemIdString" value="GRADLE"/>
            <option name="scriptParameters" value="--tests *"/>
            <option name="taskDescriptions">
                <list/>
            </option>
            <option name="taskNames">
                <list>
                    <option value=":cleanTest"/>
                    <option value=":test"/>
                </list>
            </option>
            <option name="vmOptions"/>
        </ExternalSystemSettings>
        <GradleScriptDebugEnabled/>
    </config>
    <suite duration="200" locationUrl="java:suite://org.gitlab.api.models.GitlabIssueDeserializationTest" name="org.gitlab.api.models.GitlabIssueDeserializationTest" status="passed">
        <test duration="200" locationUrl="java:test://org.gitlab.api.models.GitlabIssueDeserializationTest.deserializationTest" name="deserializationTest()" status="passed"/>
    </suite>
    <suite duration="1074" locationUrl="java:suite://org.gitlab.api.http.GitlabHTTPRequestorTest" name="org.gitlab.api.http.GitlabHTTPRequestorTest" status="passed">
        <test duration="1066" locationUrl="java:test://org.gitlab.api.http.GitlabHTTPRequestorTest.Expected success, calling the &quot;setupConnection&quot; method if the connection timeout = 0" name="Expected success, calling the &quot;setupConnection&quot; method if the connection timeout = 0" status="passed"/>
        <test duration="2" locationUrl="java:test://org.gitlab.api.http.GitlabHTTPRequestorTest.Expected success, calling the &quot;setupConnection&quot; method if the connection timeout &gt; 0" name="Expected success, calling the &quot;setupConnection&quot; method if the connection timeout &gt; 0" status="passed"/>
        <test duration="3" locationUrl="java:test://org.gitlab.api.http.GitlabHTTPRequestorTest.An error is expected, calling the &quot;setupConnection&quot; method if the connection timeout &lt; 0" name="An error is expected, calling the &quot;setupConnection&quot; method if the connection timeout &lt; 0" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.http.GitlabHTTPRequestorTest.Expected success, calling the &quot;setupConnection&quot; method if the read timeout = 0" name="Expected success, calling the &quot;setupConnection&quot; method if the read timeout = 0" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.http.GitlabHTTPRequestorTest.Expected success, calling the &quot;setupConnection&quot; method if the read timeout &gt; 0" name="Expected success, calling the &quot;setupConnection&quot; method if the read timeout &gt; 0" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.http.GitlabHTTPRequestorTest.An error is expected, calling the &quot;setupConnection&quot; method if the read timeout &lt; 0" name="An error is expected, calling the &quot;setupConnection&quot; method if the read timeout &lt; 0" status="passed"/>
    </suite>
    <suite duration="15" locationUrl="java:suite://org.gitlab.api.InstantDeserializerTest" name="org.gitlab.api.InstantDeserializerTest" status="passed">
        <test duration="15" locationUrl="java:test://org.gitlab.api.InstantDeserializerTest.deserialize" name="deserialize()" status="passed"/>
    </suite>
    <suite duration="127" locationUrl="java:suite://org.gitlab.api.GitlabAPIUT" name="org.gitlab.api.GitlabAPIUT" status="passed">
        <test duration="11" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check non-routable connection with connection timeout error" name="Check non-routable connection with connection timeout error" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check default value is 0 for connection timeout" name="Check default value is 0 for connection timeout" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check set/get methods for connection timeout parameter" name="Check set/get methods for connection timeout parameter" status="passed"/>
        <test duration="7" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check ignore negative value for connection timeout parameter" name="Check ignore negative value for connection timeout parameter" status="passed"/>
        <test duration="105" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check connection with read timeout error" name="Check connection with read timeout error" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check default value is 0 for request timeout parameter" name="Check default value is 0 for request timeout parameter" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check set/get methods for request timeout parameter" name="Check set/get methods for request timeout parameter" status="passed"/>
        <test duration="3" locationUrl="java:test://org.gitlab.api.GitlabAPIUT.Check ignore negative value for request timeout parameter" name="Check ignore negative value for request timeout parameter" status="passed"/>
    </suite>
    <suite duration="4" locationUrl="java:suite://org.gitlab.api.models.GitlabGroupTest" name="org.gitlab.api.models.GitlabGroupTest" status="passed">
        <test duration="3" locationUrl="java:test://org.gitlab.api.models.GitlabGroupTest.getLdapAccessHandlesNull" name="getLdapAccessHandlesNull" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.models.GitlabGroupTest.setLdapAccessHandlesNull" name="setLdapAccessHandlesNull" status="passed"/>
    </suite>
    <suite duration="3" locationUrl="java:suite://org.gitlab.api.http.QueryTest" name="org.gitlab.api.http.QueryTest" status="passed">
        <test duration="1" locationUrl="java:test://org.gitlab.api.http.QueryTest.mixedStyle_append" name="mixedStyle_append" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.http.QueryTest.conditionalAppend_null" name="conditionalAppend_null" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.http.QueryTest.append_encodes_values" name="append_encodes_values" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.http.QueryTest.merge" name="merge" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.http.QueryTest.fluentStyle_append" name="fluentStyle_append" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.http.QueryTest.conditionalAppend_notNull" name="conditionalAppend_notNull" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.http.QueryTest.conditionalAppend_null_notNull" name="conditionalAppend_null_notNull" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.http.QueryTest.mutableStyle_append" name="mutableStyle_append" status="passed"/>
    </suite>
    <suite duration="1" locationUrl="java:suite://org.gitlab.api.GitlabUploadIT" name="org.gitlab.api.GitlabUploadIT" status="ignored">
        <test duration="1" locationUrl="java:test://org.gitlab.api.GitlabUploadIT.classMethod" name="classMethod" status="ignored"/>
    </suite>
    <suite duration="0" locationUrl="java:suite://org.gitlab.api.GitlabJson" name="org.gitlab.api.GitlabJson" status="ignored">
        <test duration="0" locationUrl="java:test://org.gitlab.api.GitlabJson.classMethod" name="classMethod" status="ignored"/>
    </suite>
    <suite duration="0" locationUrl="java:suite://org.gitlab.api.GitlabAPIIT" name="org.gitlab.api.GitlabAPIIT" status="ignored">
        <test duration="0" locationUrl="java:test://org.gitlab.api.GitlabAPIIT.classMethod" name="classMethod" status="ignored"/>
    </suite>
    <suite duration="4" locationUrl="java:suite://org.gitlab.api.PaginationTest" name="org.gitlab.api.PaginationTest" status="passed">
        <test duration="0" locationUrl="java:test://org.gitlab.api.PaginationTest.emptyPagination" name="emptyPagination" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.PaginationTest.maxItemsPerPage" name="maxItemsPerPage" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.PaginationTest.perPageOnlyPagination" name="perPageOnlyPagination" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.PaginationTest.perPageException" name="perPageException" status="passed"/>
        <test duration="1" locationUrl="java:test://org.gitlab.api.PaginationTest.complexPagination" name="complexPagination" status="passed"/>
        <test duration="0" locationUrl="java:test://org.gitlab.api.PaginationTest.pageOnlyPagination" name="pageOnlyPagination" status="passed"/>
    </suite>
</testrun>
```