### PR TITLE
Added possibility to get only first page from project's pipelines

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -1087,6 +1087,18 @@ public class GitlabAPI {
     }
 
     /**
+     * Get the first page of project's pipelines in Gitlab.
+     *
+     * @param projectId the project id
+     * @return A list of project pipelines
+     */
+    public List<GitlabPipeline> getFirstProjectPipelinePage(Integer projectId, PipelinesQuery pipelinesQuery) {
+        String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) + GitlabPipeline.URL + pipelinesQuery;
+        return retrieve().getFirstPage(tailUrl, GitlabPipeline[].class);
+    }
+
+
+    /**
      * Gets a list of a project's jobs in Gitlab
      *
      * @param project the project

--- a/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
+++ b/src/main/java/org/gitlab/api/http/GitlabHTTPRequestor.java
@@ -173,6 +173,17 @@ public class GitlabHTTPRequestor {
         return results;
     }
 
+    public <T> List<T> getFirstPage(final String tailUrl, final Class<T[]> type) {
+        Iterator<T[]> iterator = asIterator(tailUrl, type);
+        if (iterator.hasNext()) {
+            T[] requests = iterator.next();
+            if (requests.length > 0) {
+                return Arrays.asList(requests);
+            }
+        }
+        return new ArrayList<>();
+    }
+
     public <T> Iterator<T> asIterator(final String tailApiUrl, final Class<T> type) {
         method(GET); // Ensure we only use iterators for GET requests
 


### PR DESCRIPTION
In some cases, we need to load only the first or the last page from project's pipelines using a pagination query. (e.g. get the last pipeline from the project)