### PR TITLE
Fix getting commits for a merge request originating from a (now deleted) fork

### DIFF
--- a/src/main/java/org/gitlab/api/GitlabAPI.java
+++ b/src/main/java/org/gitlab/api/GitlabAPI.java
@@ -2120,10 +2120,7 @@ public class GitlabAPI {
     }
 
     public List<GitlabCommit> getCommits(GitlabMergeRequest mergeRequest, Pagination pagination) throws IOException {
-        Integer projectId = mergeRequest.getSourceProjectId();
-        if (projectId == null) {
-            projectId = mergeRequest.getProjectId();
-        }
+        Integer projectId = mergeRequest.getProjectId();
 
         String tailUrl = GitlabProject.URL + "/" + sanitizeProjectId(projectId) +
                 GitlabMergeRequest.URL + "/" + mergeRequest.getIid() +


### PR DESCRIPTION
This method used to use the merge request's source project (e.g. a fork) to get the commits. However this appears to be unnecessary and wrong with current GitLab versions at least 14.x, 15.x).

In particular, this would fail hard when trying to get the commits after the source project was deleted.

The commits of a merge request belong to the project of the merge request and not to any other project where they may have been developed in.

This now works both for fork (still available) and fork (deleted), as well as merge requests from within the same project (no fork),